### PR TITLE
[WD-13276] add search field

### DIFF
--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -2,6 +2,7 @@
 
 @import "./settings.scss";
 @import "vanilla-framework";
+@include vanilla;
 @include vf-base;
 
 // Patterns
@@ -35,3 +36,4 @@
 @import "./components/MainLayout/MainLayout";
 @import "./components/Navigation/Navigation";
 @import "./components/Navigation/NavigationElement/NavigationElement";
+@import "./components/Search/Search";

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useLocation } from "react-router-dom";
 
 import Navigation from "@/components/Navigation";
+import Search from "@/components/Search";
 
 interface IMainLayoutProps {
   children?: JSX.Element;
@@ -20,6 +21,7 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
       <div className="l-application">
         <Navigation />
         <main className="l-main">
+          <Search />
           {location.pathname === "/" && (
             <>
               <h2>Welcome to the Content System</h2>

--- a/static/client/components/Search/Search.services.ts
+++ b/static/client/components/Search/Search.services.ts
@@ -1,0 +1,32 @@
+import type { IMatch } from "./Search.types";
+
+import type { IPage, IPagesResponse } from "@/services/api/types/pages";
+
+const checkMatches = (pages: IPage[], value: string, matches: IMatch[], project: string) => {
+  pages.forEach((page) => {
+    if (page.name?.indexOf(value) >= 0 || page.title?.indexOf(value) >= 0) {
+      matches.push({
+        name: page.name,
+        project,
+        title: page.title,
+      });
+    }
+    if (page.children?.length) {
+      checkMatches(page.children, value, matches, project);
+    }
+  });
+};
+
+export const searchForMatches = (value: string, tree: IPagesResponse[]): IMatch[] => {
+  const matches: IMatch[] = [];
+
+  tree.forEach((project) => {
+    if (project.data.templates.children?.length) {
+      checkMatches(project.data.templates.children, value, matches, project.data.name);
+    }
+  });
+
+  return matches;
+};
+
+export * as SearchServices from "./Search.services";

--- a/static/client/components/Search/Search.tsx
+++ b/static/client/components/Search/Search.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useRef, useState } from "react";
+
+import { SearchBox } from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+
+import { SearchServices } from "./Search.services";
+import type { IMatch } from "./Search.types";
+
+import { usePages } from "@/services/api/hooks/pages";
+
+const Search = (): JSX.Element => {
+  const { data } = usePages();
+  const navigate = useNavigate();
+  const [matches, setMatches] = useState<IMatch[]>([]);
+
+  const searchRef = useRef(null);
+
+  const handleChange = useCallback(
+    (inputValue: string) => {
+      if (inputValue.length > 2 && data?.length && data[0]?.data) {
+        setMatches(SearchServices.searchForMatches(inputValue, data));
+      } else if (inputValue.length === 0) {
+        setMatches([]);
+      }
+    },
+    [data],
+  );
+
+  const handleSelect = useCallback(
+    (selectedItem: IMatch) => () => {
+      setMatches([]);
+      if (searchRef?.current) {
+        (searchRef.current as any).value = "";
+      }
+      navigate(`/webpage/${selectedItem.project}${selectedItem.name}`);
+    },
+    [navigate, searchRef],
+  );
+
+  return (
+    <div className="l-search-container">
+      {
+        <SearchBox
+          disabled={!(data?.length && data[0]?.data)}
+          onChange={handleChange}
+          placeholder="Search a webpage"
+          ref={searchRef}
+        />
+      }
+      {matches.length >= 0 && (
+        <ul className="l-search-dropdown">
+          {matches.map((match) => (
+            <li className="l-search-item" onClick={handleSelect(match)}>
+              {match.name} - {match.title}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Search;

--- a/static/client/components/Search/Search.types.ts
+++ b/static/client/components/Search/Search.types.ts
@@ -1,0 +1,5 @@
+export interface IMatch {
+  name: string;
+  project: string;
+  title: string;
+}

--- a/static/client/components/Search/_Search.scss
+++ b/static/client/components/Search/_Search.scss
@@ -1,0 +1,27 @@
+.l-search-container {
+  position: relative;
+
+  .l-search-dropdown {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: rgb(38, 57, 77) 0px 20px 30px -10px;
+    left: 0;
+    list-style-type: none;
+    margin: 0;
+    max-height: calc(100vh - 200px);
+    padding: 0;
+    position: absolute;
+    top: 50px;
+    width: 100%;
+    z-index: 10;
+
+    .l-search-item {
+      padding: 5px 10px;
+
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.1);
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/static/client/components/Search/index.ts
+++ b/static/client/components/Search/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Search";


### PR DESCRIPTION
## Done

 - Added a search field that allows searching needed webpages by their names and titles

## QA

- Clone the repo
- Run `dotrun --release 1.1.0-rc1 build`
- Then run `dotrun --release 1.1.0-rc1 serve` to run the app locally
- Open 0.0.0.0:8104 in the browser
- Type something into the search field and check if the dropdown shows the webpage that you're looking for
- Select a page from the dropdown and check that it opens its view and empties the search field

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-13276
