### PR TITLE
[WD-13297] add get-users route that fetches users from directory-api

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,4 @@ GH_TOKEN=token
 REPO_ORG=https://github.com/canonical
 SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/postgres
 TASK_DELAY=30
+DIRECTORY_API_TOKEN=token

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ Flask-SQLAlchemy==3.1.1
 talisker[gunicorn,gevent,flask,prometheus,raven]==0.21.3
 valkey==6.0.0b1
 Werkzeug==2.3.8
+requests==2.31.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -7,6 +7,8 @@ from webapp.site_repository import SiteRepository
 from webapp.sso import login_required
 from webapp.tasks import LOCKS
 
+import requests
+
 app = create_app()
 
 
@@ -37,3 +39,63 @@ def get_tree(uri: str, branch="main"):
 @login_required
 def index(path):
     return render_template("index.html")
+
+
+@app.route('/get-users/<username>', methods=['GET'])
+@login_required
+def get_users(username: str):
+    first_name_query = """
+    query($name: String!) {
+        employees(filter: { firstName: $name }) {
+            id
+            name
+            email
+            team
+            department
+            jobTitle
+        }
+    }
+    """
+
+    last_name_query = """
+    query($name: String!) {
+        employees(filter: { surname: $name }) {
+            id
+            name
+            email
+            team
+            department
+            jobTitle
+        }
+    }
+    """
+
+    headers = {
+        "Authorization": "token " + environ.get("DIRECTORY_API_TOKEN")
+    }
+
+    # Currently directory-api only supports strict comparison of field values,
+    # so we have to send two requests instead of one for first and last names
+    first_name_response = requests.post(
+        "https://directory.wpe.internal/graphql/", json={
+            'query': first_name_query,
+            'variables': {'name': username},
+        }, headers=headers, verify=False)
+
+    last_name_response = requests.post(
+        "https://directory.wpe.internal/graphql/", json={
+            'query': last_name_query,
+            'variables': {'name': username},
+        }, headers=headers, verify=False)
+
+    if (first_name_response.status_code == 200 and
+            last_name_response.status_code == 200):
+        first_name_data = first_name_response.json().get('data', {}).get(
+            'employees', [])
+        last_name_data = last_name_response.json().get('data', {}).get(
+            'employees', [])
+        users = {emp['id']: emp for emp in first_name_data +
+                 last_name_data}.values()
+        return jsonify(list(users))
+    else:
+        return jsonify({"error": "Failed to fetch users"}), 500

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -74,18 +74,20 @@ def get_users(username: str):
         "Authorization": "token " + environ.get("DIRECTORY_API_TOKEN")
     }
 
+    formattedUsername = username.strip().title()
+
     # Currently directory-api only supports strict comparison of field values,
     # so we have to send two requests instead of one for first and last names
     first_name_response = requests.post(
         "https://directory.wpe.internal/graphql/", json={
             'query': first_name_query,
-            'variables': {'name': username},
+            'variables': {'name': formattedUsername},
         }, headers=headers, verify=False)
 
     last_name_response = requests.post(
         "https://directory.wpe.internal/graphql/", json={
             'query': last_name_query,
-            'variables': {'name': username},
+            'variables': {'name': formattedUsername},
         }, headers=headers, verify=False)
 
     if (first_name_response.status_code == 200 and


### PR DESCRIPTION
## Done

- Added a call to a GraphQL endpoint provided by directory-api to fetch employees by a provided string. It returns a list of employees if a provided string corresponds to either the first name or the last name of an employee. The comparison is strict, meaning a provided string should strictly correspond to one of first name or last name.
- Added an endpoint that receives a username string and returns a list of matched employees as an array of objects. This endpoint essentially calls a GraphQL endpoint and returns the result.

## QA

- Clone the repo
- Run `dotrun`
- Open the browser and navigate to `0.0.0.0:8104/get-users/<username>`
- Check that the result is expected

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-13297

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
