### PR TITLE
Return reviewer as user object

### DIFF
--- a/webapp/site_repository.py
+++ b/webapp/site_repository.py
@@ -423,6 +423,13 @@ class SiteRepository:
                 reviewer_dict.pop("_sa_instance_state", None)
                 reviewer_dict["created_at"] = reviewer.created_at.isoformat()
                 reviewer_dict["updated_at"] = reviewer.updated_at.isoformat()
+                # Expand the user object
+                reviewer_user_dict = reviewer.user.__dict__.copy()
+                reviewer_user_dict.pop("created_at")
+                reviewer_user_dict.pop("updated_at")
+                if reviewer_user_dict["_sa_instance_state"]:
+                    reviewer_user_dict.pop("_sa_instance_state", None)
+                reviewer_dict = {**reviewer_dict, **reviewer_user_dict}
                 reviewers_list.append(reviewer_dict)
         else:
             reviewers_list = []


### PR DESCRIPTION
## Done

 - Expanded the user object returned initially as `user_id` in the `reviewers` object in the tree.

## QA

### QA steps

 - Run the project and create reviewers for the webpage
 - Open `/get-tree/ubuntu.com`
 - Check that returned json for `owner` matches `reviewers`, except for the additional `webpage_id` field

## Screenshots
![image](https://github.com/user-attachments/assets/87881c02-a215-4737-aea3-7f11fe283349)

