### PR TITLE
do not show a chip for null in owner and reviewers

### DIFF
--- a/static/client/components/OwnerAndReviewers/CustomSearchAndFilter.tsx
+++ b/static/client/components/OwnerAndReviewers/CustomSearchAndFilter.tsx
@@ -59,14 +59,17 @@ const CustomSearchAndFilter = ({
         data-active="true"
         data-empty="true"
       >
-        {selectedOptions.map((option) => (
-          <span className="p-chip">
-            <span className="p-chip__value">{option.name}</span>
-            <button className="p-chip__dismiss" onClick={onRemove(option)}>
-              Dismiss
-            </button>
-          </span>
-        ))}
+        {selectedOptions.map(
+          (option) =>
+            option && (
+              <span className="p-chip">
+                <span className="p-chip__value">{option.name}</span>
+                <button className="p-chip__dismiss" onClick={onRemove(option)}>
+                  Dismiss
+                </button>
+              </span>
+            ),
+        )}
         <form className="p-search-and-filter__box" data-overflowing="false">
           <input
             aria-labelledby="owner-input"


### PR DESCRIPTION
## Done

 - In case a value is null do not show a chip in "Owner" field

## QA

- Locally this does not reproduce, since there is always a value for "Owner" field. By default there is always "Default" user. On production there is no "Default" user, so an empty object will be returned if no owner is defined. So no QA is needed, only code review.

## Screenshots
Currently on prod:
<img width="518" alt="Screenshot 2024-09-11 at 19 14 16" src="https://github.com/user-attachments/assets/8d2aec82-9808-4c2f-b583-8265e9341019">

Should be:
<img width="490" alt="Screenshot 2024-09-11 at 19 14 52" src="https://github.com/user-attachments/assets/3b20f5bd-27b7-4789-9a9a-4cd6f2ed00ca">
