### PR TITLE
Add /get-jira-tasks endpoint

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,7 +6,7 @@ from flask_pydantic import validate
 
 from webapp import create_app
 from webapp.helper import create_jira_task, get_or_create_user_id
-from webapp.models import Reviewer, Webpage, db, get_or_create
+from webapp.models import Reviewer, Webpage, JiraTask, db, get_or_create
 from webapp.schemas import (
     ChangesRequestModel,
 )
@@ -140,3 +140,28 @@ def request_changes(body: ChangesRequestModel):
         return jsonify(str(e)), 500
 
     return jsonify("Task created successfully"), 201
+
+
+@app.route("/get-jira-tasks/<webpage_id>", methods=["GET"])
+def get_jira_tasks(webpage_id: int):
+    jira_tasks = (
+        JiraTask.query.filter_by(webpage_id=webpage_id)
+                .order_by(JiraTask.created_at)
+                .all()
+    )
+    if jira_tasks:
+        tasks = []
+        for task in jira_tasks:
+            tasks.append(
+                {
+                    "id": task.id,
+                    "jira_id": task.jira_id,
+                    "status": task.status,
+                    "webpage_id": task.webpage_id,
+                    "user_id": task.user_id,
+                    "created_at": task.created_at,
+                }
+            )
+        return jsonify(tasks), 200
+    else:
+        return jsonify({"error": "Failed to fetch Jira tasks"}), 500

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -113,6 +113,7 @@ class Reviewer(db.Model, DateTimeMixin):
     user = relationship("User", back_populates="reviewers")
     webpages = relationship("Webpage", back_populates="reviewers")
 
+
 class JIRATaskStatus:
     TRIAGED = "TRIAGED"
     UNTRIAGED = "UNTRIAGED"
@@ -121,6 +122,7 @@ class JIRATaskStatus:
     TO_BE_DEPLOYED = "TO_BE_DEPLOYED"
     DONE = "DONE"
     REJECTED = "REJECTED"
+
 
 class JiraTask(db.Model, DateTimeMixin):
     __tablename__ = "jira_tasks"


### PR DESCRIPTION
## Done

 - Added `/get-jira-tasks/<webpage_id>` endpoint that returns an array of jira tasks, ordered by creation date

## QA

### QA steps

 - Go to pgAdmin and add data rows to `jira_tasks` manually
 - Example entry:
 ```
INSERT INTO jira_tasks(jira_id, webpage_id, user_id, status, created_at, updated_at)
VALUES(4, 2, 1, 2, CURRENT_TIMESTAMP - INTERVAL '1 day', CURRENT_TIMESTAMP)
```
- Create a GET request to `/get-jira-tasks/<webpage_id>`
- See that an array of jira tasks is returned, ordered by `created_at`
- Example response:
```
[
    {
        "created_at": "2024-10-02 07:15:32.449506+00",
        "id": 8,
        "jira_id": "4",
        "status": "2",
        "user_id": 1,
        "webpage_id": 2
    },
    {
        "created_at": "2024-10-03 07:01:45.950817+00",
        "id": 4,
        "jira_id": "1",
        "status": "2",
        "user_id": 1,
        "webpage_id": 2
    },
    {
        "created_at": "2024-10-03 07:02:46.360292+00",
        "id": 6,
        "jira_id": "4",
        "status": "2",
        "user_id": 1,
        "webpage_id": 2
    },
    {
        "created_at": "2024-10-03 07:14:46.034713+00",
        "id": 7,
        "jira_id": "4",
        "status": "2",
        "user_id": 1,
        "webpage_id": 2
    }
]
```

## Fixes

 - Fixes [WD-13360](https://warthogs.atlassian.net/browse/WD-13360)

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.


[WD-13360]: https://warthogs.atlassian.net/browse/WD-13360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ