### PR TITLE
[WD-13390] Request creation of Jira task for a new webpage

### DIFF
--- a/static/client/components/NewPageModal/NewPageModal.tsx
+++ b/static/client/components/NewPageModal/NewPageModal.tsx
@@ -43,10 +43,11 @@ const NewPageModal = ({ copyDocLink, onClose, webpage }: INewPageModalProps): JS
         webpage_id: webpage.id,
         reporter_id: webpage.owner.id,
         type: ChangeRequestType.NEW_WEBPAGE,
-        description: `Copy doc link: ${webpage.copy_doc_link}\n${descr}`,
+        description: `Copy doc link: ${webpage.copy_doc_link} \n${descr}`,
       }).then(() => {
         setIsLoading(false);
         onClose();
+        window.location.reload();
       });
     }
   }, [dueDate, descr, webpage, onClose]);

--- a/static/client/components/NewPageModal/NewPageModal.tsx
+++ b/static/client/components/NewPageModal/NewPageModal.tsx
@@ -1,0 +1,93 @@
+import { type ChangeEvent, useCallback, useState } from "react";
+
+import { Button, Input, Modal, Spinner, Textarea } from "@canonical/react-components";
+
+import type { INewPageModalProps } from "./NewPageModal.types";
+
+import config from "@/config";
+import { PagesServices } from "@/services/api/services/pages";
+import { ChangeRequestType } from "@/services/api/types/pages";
+
+function getNowStr() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0"); // Months are 0-based, so we add 1
+  const day = String(today.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+const NewPageModal = ({ copyDocLink, onClose, webpage }: INewPageModalProps): JSX.Element => {
+  const [dueDate, setDueDate] = useState<string>();
+  const [checked, setChecked] = useState(false);
+  const [descr, setDescr] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChangeDueDate = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setDueDate(e.target.value);
+  }, []);
+
+  const handleChangeConsent = useCallback(() => {
+    setChecked((prevValue) => !prevValue);
+  }, []);
+
+  const handleDescrChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescr(e.target.value);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (dueDate && webpage?.id) {
+      setIsLoading(true);
+      PagesServices.requestChanges({
+        due_date: dueDate,
+        webpage_id: webpage.id,
+        reporter_id: webpage.owner.id,
+        type: ChangeRequestType.NEW_WEBPAGE,
+        description: `Copy doc link: ${webpage.copy_doc_link}\n${descr}`,
+      }).then(() => {
+        setIsLoading(false);
+        onClose();
+      });
+    }
+  }, [dueDate, descr, webpage, onClose]);
+
+  return (
+    <Modal
+      buttonRow={
+        <>
+          <Button className="u-no-margin--bottom" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button appearance="positive" disabled={!dueDate || !checked} onClick={handleSubmit}>
+            {isLoading ? <Spinner /> : "Submit"}
+          </Button>
+        </>
+      }
+      close={onClose}
+      title="Submit new page for publication"
+    >
+      <Input label="Due date" min={getNowStr()} onChange={handleChangeDueDate} required type="date" />
+      <Textarea label="Description" onChange={handleDescrChange} />
+      <Input
+        checked={checked}
+        label={
+          <span>
+            I have added all the content to the{" "}
+            <a href={copyDocLink} rel="noreferrer" target="_blank">
+              copy doc
+            </a>
+            , and it is consistent with our{" "}
+            <a href={config.copyStyleGuideLink} rel="noreferrer" target="_blank">
+              copy style guides
+            </a>
+          </span>
+        }
+        onChange={handleChangeConsent}
+        required
+        type="checkbox"
+      />
+    </Modal>
+  );
+};
+
+export default NewPageModal;

--- a/static/client/components/NewPageModal/NewPageModal.types.ts
+++ b/static/client/components/NewPageModal/NewPageModal.types.ts
@@ -1,0 +1,7 @@
+import type { IPage } from "@/services/api/types/pages";
+
+export interface INewPageModalProps {
+  copyDocLink: string;
+  onClose: () => void;
+  webpage: IPage;
+}

--- a/static/client/components/NewPageModal/index.ts
+++ b/static/client/components/NewPageModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewPageModal";

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -14,6 +14,7 @@ const config = {
     },
   },
   ghLink: (project: string) => `https://github.com/canonical/${project}/tree/main/templates`,
+  copyStyleGuideLink: "https://docs.google.com/document/d/1AX-kSNztuAmShEoohe8L3LNLRnSKF7I0qkZGNeoGOok/edit?tab=t.0",
 };
 
 export default config;

--- a/static/client/pages/NewWebpage/NewWebpage.tsx
+++ b/static/client/pages/NewWebpage/NewWebpage.tsx
@@ -84,7 +84,6 @@ const NewWebpage = (): JSX.Element => {
       if (project) {
         const isNewPageExist = TreeServices.findPage(project.templates, `${location}/${titleValue}`);
         if (isNewPageExist) {
-          console.log("new page exists, should redirect");
           // TODO: there is a max depth React error on this line, needs more investigation
           setSelectedProject(project);
           window.location.href = `/webpage/${project.name}${location}/${titleValue}`;

--- a/static/client/pages/NewWebpage/NewWebpage.tsx
+++ b/static/client/pages/NewWebpage/NewWebpage.tsx
@@ -84,6 +84,7 @@ const NewWebpage = (): JSX.Element => {
       if (project) {
         const isNewPageExist = TreeServices.findPage(project.templates, `${location}/${titleValue}`);
         if (isNewPageExist) {
+          console.log("new page exists, should redirect");
           // TODO: there is a max depth React error on this line, needs more investigation
           setSelectedProject(project);
           window.location.href = `/webpage/${project.name}${location}/${titleValue}`;

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -34,6 +34,7 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
 
   const isNew = useMemo(() => page.status === PageStatus.NEW, [page]);
   const pageName = useMemo(() => page.name.split("/").reverse()[0], [page]);
+  const hasJiraTasks = useMemo(() => page.jira_tasks?.length, [page]);
 
   return (
     <div className="l-webpage">
@@ -61,7 +62,7 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
       </div>
       <div className="l-webpage--buttons">
         <>
-          {isNew && (
+          {isNew && !hasJiraTasks && (
             <Button appearance="positive" onClick={createTask}>
               Submit for publication...
             </Button>

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -1,14 +1,17 @@
-import { useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 
 import { type IWebpageProps } from "./Webpage.types";
 
+import NewPageModal from "@/components/NewPageModal";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
 import config from "@/config";
 import { PageStatus } from "@/services/api/types/pages";
 
 const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
+  const [modalOpen, setModalOpen] = useState(false);
+
   const openCopyDoc = useCallback(() => {
     window.open(page.copy_doc_link);
   }, [page]);
@@ -21,31 +24,55 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
     }
   }, [page, project]);
 
+  const createTask = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
+  const handleModalClose = useCallback(() => {
+    setModalOpen(false);
+  }, []);
+
+  const isNew = useMemo(() => page.status === PageStatus.NEW, [page]);
+  const pageName = useMemo(() => page.name.split("/").reverse()[0], [page]);
+
   return (
     <div className="l-webpage">
+      {isNew ? (
+        <h1>New page: {pageName}</h1>
+      ) : (
+        <>
+          <p className="p-text--small-caps" id="page-title">
+            Title
+          </p>
+          <h1 aria-labelledby="page-title" className="u-no-padding--top">
+            {page.title || "-"}
+          </h1>
+        </>
+      )}
       <div>
-        <p className="p-text--small-caps" id="page-title">
-          Title
-        </p>
-        <h1 aria-labelledby="page-title" className="u-no-padding--top">
-          {page.title || "-"}
-        </h1>
-      </div>
-      <div>
-        <a href={`https://${project}${page.name}`} rel="noopener noreferrer" target="_blank">
-          {`${project}${page.name}`}&nbsp;
-          <i className="p-icon--external-link" />
-        </a>
+        {isNew ? (
+          <p>{`${project}${page.name}`}</p>
+        ) : (
+          <a href={`https://${project}${page.name}`} rel="noopener noreferrer" target="_blank">
+            {`${project}${page.name}`}&nbsp;
+            <i className="p-icon--external-link" />
+          </a>
+        )}
       </div>
       <div className="l-webpage--buttons">
         <>
+          {isNew && (
+            <Button appearance="positive" onClick={createTask}>
+              Submit for publication...
+            </Button>
+          )}
           {page.copy_doc_link && (
             <Button appearance="neutral" onClick={openCopyDoc}>
               Edit copy doc&nbsp;
               <i className="p-icon--external-link" />
             </Button>
           )}
-          {page.status !== PageStatus.NEW && (
+          {!isNew && (
             <Button appearance="neutral" onClick={openGitHub}>
               Inspect code on GitHub&nbsp;
               <i className="p-icon--external-link" />
@@ -54,16 +81,19 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
         </>
       </div>
       <div className="row">
-        <div className="col-7">
-          <p className="p-text--small-caps" id="page-descr">
-            Description
-          </p>
-          <p aria-labelledby="page-descr">{page.description || "-"}</p>
-        </div>
-        <div className="col-5">
+        {!isNew && (
+          <div className="col-7">
+            <p className="p-text--small-caps" id="page-descr">
+              Description
+            </p>
+            <p aria-labelledby="page-descr">{page.description || "-"}</p>
+          </div>
+        )}
+        <div className={isNew ? "col-12" : "col-5"}>
           <OwnerAndReviewers page={page} />
         </div>
       </div>
+      {modalOpen && <NewPageModal copyDocLink={page.copy_doc_link} onClose={handleModalClose} webpage={page} />}
     </div>
   );
 };

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -5,6 +5,7 @@ export const ENDPOINTS = {
   setOwner: "/api/set-owner",
   setReviewers: "/api/set-reviewers",
   createNewPage: "/api/create-page",
+  requestChanges: "/api/request-changes",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -1,7 +1,7 @@
 import { BasicApiClass } from "./BasicApiClass";
 
 import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
-import type { INewPage, INewPageResponse, IPagesResponse } from "@/services/api/types/pages";
+import type { INewPage, INewPageResponse, IPagesResponse, IRequestChanges } from "@/services/api/types/pages";
 import { type IUser } from "@/services/api/types/users";
 
 export class PagesApiClass extends BasicApiClass {
@@ -25,5 +25,9 @@ export class PagesApiClass extends BasicApiClass {
 
   public createPage(page: INewPage): Promise<INewPageResponse> {
     return this.callApi(ENDPOINTS.createNewPage, REST_TYPES.POST, page);
+  }
+
+  public requestChanges(body: IRequestChanges): Promise<void> {
+    return this.callApi(ENDPOINTS.requestChanges, REST_TYPES.POST, body);
   }
 }

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -1,5 +1,5 @@
 import { api } from "@/services/api";
-import type { INewPage, INewPageResponse, IPagesResponse } from "@/services/api/types/pages";
+import type { INewPage, INewPageResponse, IPagesResponse, IRequestChanges } from "@/services/api/types/pages";
 import type { IUser } from "@/services/api/types/users";
 
 export const getPages = async (domain: string, noCache?: boolean): Promise<IPagesResponse> => {
@@ -16,6 +16,10 @@ export const setReviewers = async (users: IUser[], webpageId: number): Promise<v
 
 export const createPage = async (page: INewPage): Promise<INewPageResponse> => {
   return api.pages.createPage(page);
+};
+
+export const requestChanges = async (body: IRequestChanges): Promise<void> => {
+  return api.pages.requestChanges(body);
 };
 
 export * as PagesServices from "./pages";

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -6,6 +6,14 @@ export const PageStatus = {
   TO_DELETE: "TO_DELETE",
 };
 
+export interface IJiraTask {
+  created_at: string;
+  jira_id: string;
+  id: number;
+  name: string;
+  status: string;
+}
+
 export interface IPage {
   id?: number;
   name: string;
@@ -15,7 +23,7 @@ export interface IPage {
   owner: IUser;
   reviewers: IUser[];
   status: (typeof PageStatus)[keyof typeof PageStatus];
-  jira_tasks: any[];
+  jira_tasks: IJiraTask[];
   children: IPage[];
 }
 

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -15,6 +15,7 @@ export interface IPage {
   owner: IUser;
   reviewers: IUser[];
   status: (typeof PageStatus)[keyof typeof PageStatus];
+  jira_tasks: any[];
   children: IPage[];
 }
 
@@ -36,4 +37,18 @@ export interface INewPage {
 
 export interface INewPageResponse {
   copy_doc: string;
+}
+
+export const ChangeRequestType = {
+  COPY_UPDATE: 0,
+  PAGE_REFRESH: 1,
+  NEW_WEBPAGE: 2,
+};
+
+export interface IRequestChanges {
+  due_date: string;
+  reporter_id: number;
+  webpage_id: number;
+  type: (typeof ChangeRequestType)[keyof typeof ChangeRequestType];
+  description: string;
 }

--- a/webapp/helper.py
+++ b/webapp/helper.py
@@ -33,7 +33,6 @@ def create_jira_task(app, task):
         webpage_id=task["webpage_id"],
         request_type=task["type"],
         description=task["description"],
-        summary=task["summary"] or "",
     )
 
     # Create jira task in the database

--- a/webapp/helper.py
+++ b/webapp/helper.py
@@ -72,6 +72,7 @@ def convert_webpage_to_dict(webpage, owner, project):
     owner = webpage_dict.pop("owner", None)
     project = webpage_dict.pop("project", None)
     reviewers = webpage_dict.pop("reviewers", None)
+    jira_tasks = webpage_dict.pop("jira_tasks", None)
 
     # Serialize owner fields
     if owner:
@@ -112,6 +113,25 @@ def convert_webpage_to_dict(webpage, owner, project):
     else:
         reviewers_list = []
 
+    # Serialize jira_tasks fields
+    if jira_tasks:
+        jira_tasks_list = []
+        for jira_task in jira_tasks:
+            jira_task_dict = jira_task.__dict__.copy()
+            jira_task_dict.pop("_sa_instance_state", None)
+            jira_task_dict["created_at"] = jira_task.created_at.isoformat()
+            jira_task_dict["updated_at"] = jira_task.updated_at.isoformat()
+            # Expand the user object
+            jira_task_user_dict = jira_task.user.__dict__.copy()
+            jira_task_user_dict.pop("created_at")
+            jira_task_user_dict.pop("updated_at")
+            if jira_task_user_dict["_sa_instance_state"]:
+                jira_task_user_dict.pop("_sa_instance_state", None)
+            jira_task_dict = {**jira_task_dict, **jira_task_user_dict}
+            jira_tasks_list.append(jira_task_dict)
+    else:
+        jira_tasks_list = []
+
     # Serialize object fields
     webpage_dict["status"] = webpage.status.value
     webpage_dict["created_at"] = webpage.created_at.isoformat()
@@ -119,6 +139,7 @@ def convert_webpage_to_dict(webpage, owner, project):
     webpage_dict["owner"] = owner_dict
     webpage_dict["project"] = project_dict
     webpage_dict["reviewers"] = reviewers_list
+    webpage_dict["jira_tasks"] = jira_tasks_list
 
     return webpage_dict
 

--- a/webapp/jira.py
+++ b/webapp/jira.py
@@ -182,7 +182,6 @@ class Jira:
         reporter_id: str,
         webpage_id: int,
         due_date: datetime,
-        summary: str,
     ):
         """Creates a new issue in Jira.
 


### PR DESCRIPTION
## Done

- Changed UI for new webpages to signify that they are new
- Added "Submit for publication" button that opens a modal with several fields. Submitting the modal form calls `/api/request-changes` endpoint that creates a Jira task for a new webpage

## QA

### QA steps

 - Run the app locally using `dotrun`
 - Open `0.0.0.0:8104` in the browser
 - Check that the tree shows data for both `canonical.com` and `ubuntu.com`. If not, refresh the page and check again (the DB might be filling up, which can take a bit of a time)
 - Click on `Request new page` button in the sidebar
 - Make sure you have a VPN connection on
 - Fill in the fields that are required for "Save and generate copy doc" button to become enabled.
    - those are "URL title", "Location" and "Owner"
 - Click on the "Save and generate copy doc" button and check that the new webpage was created and appears in the tree of the sidebar (and is active)
 - Check that "Edit copy doc" and "Submit for publication" button show for the new webpage
 - Click on "Submit for publication" button, it should open the modal
 - Fill in the required fields in the modal
 - Click on "Submit" button and wait until the modal closes
 - Check that "Submit for publication" button is not showing anymore
    - It would also be nice to check that the response of the `/get-tree` endpoint now returns data for the new webpage together with the new Jira task (in `jira_tasks` field)
    - Or you can check that through pgAdmin or similar app that connects to your local database. The new Jira task will be stored in `jira_tasks` table.

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-13390
