### PR TITLE
[WD-13392] Request changes and remove existing webpage functionality

### DIFF
--- a/static/client/components/NewPageModal/NewPageModal.types.ts
+++ b/static/client/components/NewPageModal/NewPageModal.types.ts
@@ -1,7 +1,0 @@
-import type { IPage } from "@/services/api/types/pages";
-
-export interface INewPageModalProps {
-  copyDocLink: string;
-  onClose: () => void;
-  webpage: IPage;
-}

--- a/static/client/components/NewPageModal/index.ts
+++ b/static/client/components/NewPageModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./NewPageModal";

--- a/static/client/components/OwnerAndReviewers/Owner.tsx
+++ b/static/client/components/OwnerAndReviewers/Owner.tsx
@@ -27,9 +27,10 @@ const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element =>
   const selectOwner = useCallback(
     (option: IUser) => {
       if (page?.id) {
-        PagesServices.setOwner(option, page.id);
-        // mutate the tree structure element to reflect the recent change
-        page.owner = option;
+        PagesServices.setOwner(option, page.id).then(() => {
+          // reload the page for the new owner to appear in the pages tree
+          window.location.reload();
+        });
       }
       setOptions([]);
       setCurrentOwner(option);

--- a/static/client/components/OwnerAndReviewers/Reviewers.tsx
+++ b/static/client/components/OwnerAndReviewers/Reviewers.tsx
@@ -19,7 +19,11 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
     (option?: IUser) => () => {
       const newReviewers = currentReviewers.filter((r) => r.id !== option?.id);
       setCurrentReviewers(newReviewers);
-      if (page?.id) PagesServices.setReviewers(newReviewers, page.id);
+      if (page?.id)
+        PagesServices.setReviewers(newReviewers, page.id).then(() => {
+          // reload the page for the reviewer to be removed from the pages tree
+          window.location.reload();
+        });
       if (onSelectReviewers) onSelectReviewers(newReviewers);
     },
     [currentReviewers, page, onSelectReviewers],
@@ -32,9 +36,10 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
       if (!currentReviewers.find((r) => r.email === option.email)) {
         const newReviewers = [...currentReviewers, option];
         if (page?.id) {
-          PagesServices.setReviewers(newReviewers, page.id);
-          // mutate the tree structure element to reflect the recent change
-          page.reviewers = newReviewers;
+          PagesServices.setReviewers(newReviewers, page.id).then(() => {
+            // reload the page for the new reviewer to appear in the pages tree
+            window.location.reload();
+          });
         }
         setOptions([]);
         setCurrentReviewers(newReviewers);

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -6,7 +6,7 @@ import type { IRequestTaskModalProps } from "./RequestTaskModal.types";
 
 import config from "@/config";
 import { PagesServices } from "@/services/api/services/pages";
-import { ChangeRequestType } from "@/services/api/types/pages";
+import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";
 import { DatesServices } from "@/services/dates";
 
 const RequestTaskModal = ({
@@ -57,7 +57,11 @@ const RequestTaskModal = ({
         }).then(() => {
           setIsLoading(false);
           onClose();
-          window.location.href = "/";
+          if (webpage.status === PageStatus.NEW) {
+            window.location.href = "/";
+          } else {
+            window.location.reload();
+          }
         });
       } else {
         PagesServices.requestChanges({

--- a/static/client/components/RequestTaskModal/RequestTaskModal.types.ts
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.types.ts
@@ -1,0 +1,9 @@
+import type { ChangeRequestType, IPage } from "@/services/api/types/pages";
+
+export interface IRequestTaskModalProps {
+  changeType: (typeof ChangeRequestType)[keyof typeof ChangeRequestType];
+  copyDocLink: string;
+  onClose: () => void;
+  onTypeChange: React.Dispatch<React.SetStateAction<number>>;
+  webpage: IPage;
+}

--- a/static/client/components/RequestTaskModal/index.ts
+++ b/static/client/components/RequestTaskModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RequestTaskModal";

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -5,13 +5,16 @@ import { Button } from "@canonical/react-components";
 import { type IWebpageProps } from "./Webpage.types";
 
 import JiraTasks from "@/components/JiraTasks";
-import NewPageModal from "@/components/NewPageModal";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
+import RequestTaskModal from "@/components/RequestTaskModal";
 import config from "@/config";
-import { PageStatus } from "@/services/api/types/pages";
+import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";
 
 const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
   const [modalOpen, setModalOpen] = useState(false);
+  const [changeType, setChangeType] = useState<(typeof ChangeRequestType)[keyof typeof ChangeRequestType]>(
+    ChangeRequestType.COPY_UPDATE,
+  );
 
   const openCopyDoc = useCallback(() => {
     window.open(page.copy_doc_link);
@@ -25,7 +28,13 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
     }
   }, [page, project]);
 
-  const createTask = useCallback(() => {
+  const createNewPage = useCallback(() => {
+    setChangeType(ChangeRequestType.NEW_WEBPAGE);
+    setModalOpen(true);
+  }, []);
+
+  const requestChanges = useCallback(() => {
+    setChangeType(ChangeRequestType.COPY_UPDATE);
     setModalOpen(true);
   }, []);
 
@@ -64,8 +73,13 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
       <div className="l-webpage--buttons">
         <>
           {isNew && !hasJiraTasks && (
-            <Button appearance="positive" onClick={createTask}>
+            <Button appearance="positive" onClick={createNewPage}>
               Submit for publication...
+            </Button>
+          )}
+          {!isNew && (
+            <Button appearance="positive" onClick={requestChanges}>
+              Request changes
             </Button>
           )}
           {page.copy_doc_link && (
@@ -101,7 +115,15 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
           <JiraTasks tasks={page.jira_tasks} />
         </div>
       ) : null}
-      {modalOpen && <NewPageModal copyDocLink={page.copy_doc_link} onClose={handleModalClose} webpage={page} />}
+      {modalOpen && (
+        <RequestTaskModal
+          changeType={changeType}
+          copyDocLink={page.copy_doc_link}
+          onClose={handleModalClose}
+          onTypeChange={setChangeType}
+          webpage={page}
+        />
+      )}
     </div>
   );
 };

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -38,6 +38,11 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
     setModalOpen(true);
   }, []);
 
+  const requestRemoval = useCallback(() => {
+    setChangeType(ChangeRequestType.PAGE_REMOVAL);
+    setModalOpen(true);
+  }, []);
+
   const handleModalClose = useCallback(() => {
     setModalOpen(false);
   }, []);
@@ -94,6 +99,9 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
               <i className="p-icon--external-link" />
             </Button>
           )}
+          <Button appearance="neutral" onClick={requestRemoval}>
+            Request removal
+          </Button>
         </>
       </div>
       <div className="row">

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -6,6 +6,7 @@ export const ENDPOINTS = {
   setReviewers: "/api/set-reviewers",
   createNewPage: "/api/create-page",
   requestChanges: "/api/request-changes",
+  requestRemoval: "/api/remove-webpage",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -1,7 +1,13 @@
 import { BasicApiClass } from "./BasicApiClass";
 
 import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
-import type { INewPage, INewPageResponse, IPagesResponse, IRequestChanges } from "@/services/api/types/pages";
+import type {
+  INewPage,
+  INewPageResponse,
+  IPagesResponse,
+  IRequestChanges,
+  IRequestRemoval,
+} from "@/services/api/types/pages";
 import { type IUser } from "@/services/api/types/users";
 
 export class PagesApiClass extends BasicApiClass {
@@ -29,5 +35,9 @@ export class PagesApiClass extends BasicApiClass {
 
   public requestChanges(body: IRequestChanges): Promise<void> {
     return this.callApi(ENDPOINTS.requestChanges, REST_TYPES.POST, body);
+  }
+
+  public requestRemoval(body: IRequestRemoval): Promise<void> {
+    return this.callApi(ENDPOINTS.requestRemoval, REST_TYPES.POST, body);
   }
 }

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -1,5 +1,11 @@
 import { api } from "@/services/api";
-import type { INewPage, INewPageResponse, IPagesResponse, IRequestChanges } from "@/services/api/types/pages";
+import type {
+  INewPage,
+  INewPageResponse,
+  IPagesResponse,
+  IRequestChanges,
+  IRequestRemoval,
+} from "@/services/api/types/pages";
 import type { IUser } from "@/services/api/types/users";
 
 export const getPages = async (domain: string, noCache?: boolean): Promise<IPagesResponse> => {
@@ -20,6 +26,10 @@ export const createPage = async (page: INewPage): Promise<INewPageResponse> => {
 
 export const requestChanges = async (body: IRequestChanges): Promise<void> => {
   return api.pages.requestChanges(body);
+};
+
+export const requestRemoval = async (body: IRequestRemoval): Promise<void> => {
+  return api.pages.requestRemoval(body);
 };
 
 export * as PagesServices from "./pages";

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -52,6 +52,7 @@ export const ChangeRequestType = {
   COPY_UPDATE: 0,
   PAGE_REFRESH: 1,
   NEW_WEBPAGE: 2,
+  PAGE_REMOVAL: 3,
 };
 
 export interface IRequestChanges {
@@ -60,5 +61,12 @@ export interface IRequestChanges {
   webpage_id: number;
   type: (typeof ChangeRequestType)[keyof typeof ChangeRequestType];
   summary?: string;
+  description: string;
+}
+
+export interface IRequestRemoval {
+  due_date: string;
+  reporter_id: number;
+  webpage_id: number;
   description: string;
 }

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -201,7 +201,7 @@ def get_jira_tasks(webpage_id: int):
         return jsonify({"error": "Failed to fetch Jira tasks"}), 500
 
 
-@app.route("/api/remove_webpage", methods=["POST"])
+@app.route("/api/remove-webpage", methods=["POST"])
 @validate()
 @login_required
 def remove_webpage(body: RemoveWebpageModel):
@@ -265,7 +265,7 @@ def remove_webpage(body: RemoveWebpageModel):
 
         return (
             jsonify({"message": "Webpage has been removed successfully"}),
-            201,
+            200,
         )
 
     if webpage.status == WebpageStatus.AVAILABLE:
@@ -291,11 +291,16 @@ def remove_webpage(body: RemoveWebpageModel):
         )
         db.session.commit()
 
+    project = Project.query.filter_by(id=webpage.project_id).first()
+    site_repository = SiteRepository(project.name, app, task_locks=LOCKS)
+    # clean the cache for a page to be removed from the tree
+    site_repository.invalidate_cache()
+
     return (
         jsonify(
             {"message": f"removal of {webpage.name} processed successfully"}
         ),
-        201,
+        200,
     )
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -124,6 +124,12 @@ def set_reviewers():
             db.session, Reviewer, user_id=user_id, webpage_id=webpage_id
         )
 
+    webpage = Webpage.query.filter_by(id=webpage_id).first()
+    project = Project.query.filter_by(id=webpage.project_id).first()
+    site_repository = SiteRepository(project.name, app, task_locks=LOCKS)
+    # clean the cache for a the new reviewers to appear in the tree
+    site_repository.invalidate_cache()
+
     return jsonify({"message": "Successfully set reviewers"}), 200
 
 
@@ -141,6 +147,11 @@ def set_owner():
     if webpage:
         webpage.owner_id = user_id
         db.session.commit()
+
+        project = Project.query.filter_by(id=webpage.project_id).first()
+        site_repository = SiteRepository(project.name, app, task_locks=LOCKS)
+        # clean the cache for a new owner to appear in the tree
+        site_repository.invalidate_cache()
 
     return jsonify({"message": "Successfully set owner"}), 200
 

--- a/webapp/helper.py
+++ b/webapp/helper.py
@@ -188,7 +188,10 @@ def build_tree(session, page, webpages):
 
 
 def get_tree_struct(session, webpages):
-    webpages_list = list(webpages)
+    # sort webpages list by their name
+    webpages_list = sorted(
+        list(webpages), key=lambda p: p.name.rsplit("/", 1)[-1]
+    )
     parent_page = next(
         filter(lambda p: p.parent_id is None, webpages_list), None
     )


### PR DESCRIPTION
## Done

 - Fixed sorting of the webpages that were fetched from the database
 - Added "Request changes" button to a Webpage view that will create a Jira task for copy updates and page refreshes
 - Added "Request removal" button on a Webpage view that will create a Jira task for removing an existing page, or remove a webpage if it's new

## QA

### QA steps

 - Run the app locally using `dotrun`
 - Open `0.0.0.0:8104` in your browser
 - Check that the tree is well sorted alphabetically (if not, clear up the database and make it propagate from the repository again)
 - Open an existing page (not new one) and click on "Request changes" button. 
    - This should open a modal. Fill in the required fields and click on "Submit" button
    - Check that a new Jira task is created and is shown on the webpage view
    - Click on the link to Jira task and check that the Jira task has the correct fields and complies with the chosen request type (copy update or page refresh)
 - Open an existing page and click on "Request removal".
    - This should open a modal. Fill in the required fields and click on "Submit" button
    - Check that a new Jira task is created and is shown on the webpage view
    - Click on the link to Jira task and check that the Jira task has the correct fields and complies with the chosen request type (page removal)
    - From the database check that the `status` field of the page is "TO_DELETE"

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-13392
