### PR TITLE
Removed get-tree from cache

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -12,8 +12,9 @@ from webapp.tasks import init_tasks
 
 def set_cache_control_headers(response):
     if flask.request.path.startswith("/api/get-tree"):
-        # Our status endpoints need to be uncached
-        # to report accurate information at all times
+        # Our tree endpoints need to be uncached
+        # to prevent caching empty trees. We instead use
+        # a locally implemented cache for tree responses
         response.cache_control.no_store = True
 
 

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,4 +1,3 @@
-import flask
 from flask import Flask
 
 from webapp.cache import init_cache

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,3 +1,4 @@
+import flask
 from flask import Flask
 
 from webapp.cache import init_cache
@@ -9,12 +10,22 @@ from webapp.sso import init_sso
 from webapp.tasks import init_tasks
 
 
+def set_cache_control_headers(response):
+    if flask.request.path.startswith("/api/get-tree"):
+        # Our status endpoints need to be uncached
+        # to report accurate information at all times
+        response.cache_control.no_store = True
+
+
 def create_app():
     app = Flask(
         __name__, template_folder="../templates", static_folder="../static"
     )
     app.config.from_pyfile("settings.py")
     app.context_processor(base_context)
+
+    # Set cache control headers
+    app.after_request(set_cache_control_headers)
 
     # Initialize database
     init_db(app)

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -10,23 +10,12 @@ from webapp.sso import init_sso
 from webapp.tasks import init_tasks
 
 
-def set_cache_control_headers(response):
-    if flask.request.path.startswith("/api/get-tree"):
-        # Our tree endpoints need to be uncached
-        # to prevent caching empty trees. We instead use
-        # a locally implemented cache for tree responses
-        response.cache_control.no_store = True
-
-
 def create_app():
     app = Flask(
         __name__, template_folder="../templates", static_folder="../static"
     )
     app.config.from_pyfile("settings.py")
     app.context_processor(base_context)
-
-    # Set cache control headers
-    app.after_request(set_cache_control_headers)
 
     # Initialize database
     init_db(app)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -56,8 +56,10 @@ def get_tree(uri: str, branch: str = "main", no_cache: bool = False):
         }
     )
 
-    DEVELOPMENT_MODE = environ.get("DEVEL", True)
-    if DEVELOPMENT_MODE:
+    # Disable caching for this response
+    response.cache_control.no_store = True
+    # Allow CORS in development mode
+    if app.config["DEVELOPMENT_MODE"]:
         response.headers.add("Access-Control-Allow-Origin", "*")
 
     return response

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -31,3 +31,4 @@ GOOGLE_CREDENTIALS = {
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/websites-copy-docs-627%40web-engineering-436014.iam.gserviceaccount.com",  # noqa: E501
     "universe_domain": "googleapis.com",
 }
+DEVELOPMENT_MODE = environ.get("DEVEL", True)


### PR DESCRIPTION
## Done

 - Added cache control headers to the `/api/get-tree` endpoint. We often need to ask IS to clear the content-cache whenever the results from this endpoint are stale, especially when no data is returned.

### QA steps

 - Open https://websites-content-system-77.demos.haus/api/get-tree/ubuntu.com/main and check that the `Cache-Control: no-store` header is set.

