### PR TITLE
Added login page for sso compliance

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block content %}
+    <header id="navigation" class="p-navigation is-dark">
+        <div class="p-navigation__row--25-75">
+            <div class="p-navigation__banner">
+                <div class="p-navigation__tagged-logo">
+                    <a class="p-navigation__link" href="#">
+                        <div class="p-navigation__logo-tag">
+                            <img class="p-navigation__logo-icon"
+                                 src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
+                                 alt="">
+                        </div>
+                        <span class="p-navigation__logo-title">Content System</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </header>
+    <section class="p-strip">
+        <div class="row">
+            <div class="col">
+                <h2>Welcome to the sites content system</h2>
+                <p>
+                    To access the dashboard, log in using your <a target="_blank"
+    aria-label="External link to Ubuntu One"
+    href="https://login.ubuntu.com"><i class="p-icon--external-link"></i>Ubuntu One</a> account.
+                </p>
+                <a class="p-button--positive button" href="/login?next=/">Login with U1</a>
+            </div>
+        </div>
+    </section>
+    <footer class="p-strip--light l-footer--sticky">
+        <div class="row">
+            <div class="col-12">
+                <p>&copy; 2024 Canonical Ltd.</p>
+                <p>Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+                <nav>
+                    <ul class="p-inline-list--middot">
+                      <li class="p-inline-list__item">
+                        <a aria-label="External link to the Ubuntu legal information page" href="http://www.ubuntu.com/legal">
+                          Legal information
+                        </a>
+                      </li>
+                      <li class="p-inline-list__item">
+                        <a aria-label="External link to report a bug on Github" href="https://github.com/canonical/websites-content-system/issues/new">
+                          Report a bug on this site
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+            </div>
+        </div>
+    </footer>
+{% endblock %}

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -79,9 +79,14 @@ def set_cache_control_headers(response):
     Default caching rules that should work for most pages
     """
 
-    if flask.request.path.startswith("/_status"):
+    if flask.request.path.startswith(
+        "/_status"
+    ) or flask.request.path.startswith("/"):
         # Our status endpoints need to be uncached
-        # to report accurate information at all times
+        # to report accurate information at all times.
+        # The base path is also uncached to ensure that we don't cache the base
+        # state after logging in. We can do this as we serve a single page app
+        # from a unique url.
         response.cache_control.no_store = True
 
     elif (

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -45,7 +45,11 @@ def init_sso(app: flask.Flask):
         if "openid" in flask.session and flask.request.path == "/logout":
             flask.session.pop("openid")
 
-        return flask.redirect("/login")
+        return flask.redirect("/login_page")
+
+    @app.route("/login_page")
+    def login_page():
+        return flask.render_template("login.html")
 
 
 def login_required(func):
@@ -67,6 +71,6 @@ def login_required(func):
         if "openid" in flask.session:
             return func(*args, **kwargs)
 
-        return flask.redirect("/login?next=" + flask.request.path)
+        return flask.redirect("/login_page" + flask.request.path)
 
     return is_user_logged_in

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -42,7 +42,7 @@ def init_sso(app: flask.Flask):
 
     @app.route("/logout")
     def logout():
-        if "openid" in flask.session and flask.request.path == "/logout":
+        if "openid" in flask.session:
             flask.session.pop("openid")
 
         return flask.redirect("/login_page")


### PR DESCRIPTION
## Done

 - Added an explicit login page to comply with login.ubuntu.com SSO configuration. 

Logging in with SSO is inconsistent on staging and production due to CORS headers being modified or stripped by the content-cache during the redirect to login.ubuntu.com. With this page, the redirect is triggered by the user hence avoiding needing CORS.

## QA

 - Open the demo. If not logged in, you should be directed to `/login_page`. Clicking the log in button should trigger the sso flow, and redirect you to the dashboard.
 - Logging out should redirect you to `/login_page`
