### PR TITLE
feat:WD-32402: Create GitHub API interaction for creating updating the releases yaml

### DIFF
--- a/webapp/github.py
+++ b/webapp/github.py
@@ -80,7 +80,7 @@ class GitHubBase:
         if blob:
             return response.content
 
-        if response.status_code == 200:
+        if response.status_code in [200, 201, 204]:
             return response.text if raw else response.json()
 
         message = (

--- a/webapp/releases_manager.py
+++ b/webapp/releases_manager.py
@@ -7,6 +7,7 @@ RELEASES_REPO = "canonical/ubuntu.com"
 # RELEASES_FILE_PATH = "releases.yaml"
 RELEASES_FILE_PATH = "_TEST_releases.yaml"  # Temporary for testing
 RELEASES_BRANCH_NAME = "_releases_branch"
+BASE_BRANCH_NAME = "main"
 
 
 class TaggedField:
@@ -81,7 +82,7 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         """
         url = f"repos/{self.repo}/contents/{self.file_path}"
         pr = self.fetch_releases_pr()
-        ref = "main"
+        ref = BASE_BRANCH_NAME
 
         branch_exists = pr or self.fetch_releases_branch()
         if branch_exists:
@@ -127,6 +128,84 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
                 return None
             raise
 
+    def merge_base_into_release(self) -> dict | None:
+        """Merge base branch into the release branch if there are no conflicts.
+
+        Returns:
+            dict: Result of merge operation.
+            None: If the branch does not exist.
+
+        Raises:
+            GithubError: If the merge operation fails for other reasons.
+        """
+        if not self.fetch_releases_branch():
+            return None
+
+        url = f"repos/{self.repo}/merges"
+        payload = {
+            "base": RELEASES_BRANCH_NAME,
+            "head": BASE_BRANCH_NAME,
+            "commit_message": f"Merge {BASE_BRANCH_NAME} into {RELEASES_BRANCH_NAME}",
+        }
+
+        try:
+            response = self._request("POST", url, data=payload, raw=True)
+            return {"success": True, "merge": response}
+        except GithubError as e:
+            if e.status_code == 409:
+                return {
+                    "success": False,
+                    "error": "Merge conflict detected. Please resolve conflicts manually.",
+                }
+            raise
+
+    def update_releases_yaml(
+        self, new_content: str, commit_message: str = "Update releases.yaml"
+    ) -> dict:
+        """Update the releases.yaml file on the release branch and create a commit.
+
+        Args:
+            new_content: The new YAML content as a string.
+            commit_message: The commit message for the update. Defaults to "Update releases.yaml".
+
+        Returns:
+            dict: The commit response data.
+
+        Raises:
+            GithubError: If the update operation fails.
+        """
+        import base64
+
+        url = f"repos/{self.repo}/contents/{self.file_path}"
+
+        # Get the current file to obtain its SHA (required for updates)
+        try:
+            current_file = self._request(
+                "GET", url, params={"ref": RELEASES_BRANCH_NAME}
+            )
+            file_sha = current_file["sha"]
+        except GithubError as e:
+            if e.status_code == 404:
+                file_sha = None
+            else:
+                raise
+
+        # Encode the new content in base64
+        encoded_content = base64.b64encode(new_content.encode()).decode()
+
+        params = {
+            "message": commit_message,
+            "content": encoded_content,
+            "branch": RELEASES_BRANCH_NAME,
+        }
+
+        if file_sha:
+            params["sha"] = file_sha
+
+        # Update the file
+        response = self._request("PUT", url, data=params)
+        return response
+
 
 class ReleasesService:
     def __init__(self):
@@ -147,3 +226,69 @@ class ReleasesService:
             "releases": self.parser.parse_yaml(yaml_content),
             "status": status,
         }
+
+    def update_releases_workflow(
+        self, json_content: str, commit_message: str = "Update releases.yaml"
+    ) -> dict:
+        """Update the releases.yaml file in GitHub with new content.
+
+        Args:
+            json_content: The new JSON content as a string.
+            commit_message: The commit message for the update.
+
+        Returns:
+            A dictionary with the update status and any relevant information.
+        """
+
+        # need to convert json content that we get from the parser back to yaml string before sending to github client
+        yaml_content = json_content
+
+        try:
+            branch = self.github_client.fetch_releases_branch()
+            if not branch:
+                # TODO: Create the branch from base branch if it doesn't exist
+                # https://warthogs.atlassian.net/browse/WD-30487
+                return {
+                    "success": False,
+                    "error": "Release branch does not exist. Please create it first.",
+                }
+
+            # Merge base branch into release branch to ensure it's up to date
+            merge_result = self.github_client.merge_base_into_release()
+            if not merge_result.get("success"):
+                return merge_result
+
+            update_result = self.github_client.update_releases_yaml(
+                yaml_content, commit_message
+            )
+
+            # Check if PR exists
+            pr = self.github_client.fetch_releases_pr()
+
+            if not pr:
+                # TODO: Create PR automatically
+                # https://warthogs.atlassian.net/browse/WD-30487
+                return {
+                    "success": True,
+                    "message": "File updated successfully. Please create a PR manually.",
+                    "commit": update_result,
+                    "branch": RELEASES_BRANCH_NAME,
+                }
+
+            return {
+                "success": True,
+                "message": "releases.yaml updated successfully.",
+                "commit": update_result,
+                "pr": {
+                    "number": pr.get("number"),
+                    "url": pr.get("html_url"),
+                    "title": pr.get("title"),
+                },
+            }
+
+        except GithubError as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "status_code": e.status_code,
+            }

--- a/webapp/releases_manager.py
+++ b/webapp/releases_manager.py
@@ -145,7 +145,8 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         payload = {
             "base": RELEASES_BRANCH_NAME,
             "head": BASE_BRANCH_NAME,
-            "commit_message": f"Merge {BASE_BRANCH_NAME} into {RELEASES_BRANCH_NAME}",
+            "commit_message": f"Merge {BASE_BRANCH_NAME}"
+            f" into {RELEASES_BRANCH_NAME}",
         }
 
         try:
@@ -155,18 +156,21 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
             if e.status_code == 409:
                 return {
                     "success": False,
-                    "error": "Merge conflict detected. Please resolve conflicts manually.",
+                    "error": "Merge conflict detected."
+                    " Please resolve conflicts manually.",
                 }
             raise
 
     def update_releases_yaml(
         self, new_content: str, commit_message: str = "Update releases.yaml"
     ) -> dict:
-        """Update the releases.yaml file on the release branch and create a commit.
+        """Update the releases.yaml file on the release branch
+        and create a commit.
 
         Args:
             new_content: The new YAML content as a string.
-            commit_message: The commit message for the update. Defaults to "Update releases.yaml".
+            commit_message: The commit message for the update.
+            Defaults to "Update releases.yaml".
 
         Returns:
             dict: The commit response data.
@@ -240,7 +244,8 @@ class ReleasesService:
             A dictionary with the update status and any relevant information.
         """
 
-        # need to convert json content that we get from the parser back to yaml string before sending to github client
+        # need to convert json content that we get from the parser back
+        # to yaml string before sending to github client
         yaml_content = json_content
 
         try:
@@ -250,7 +255,8 @@ class ReleasesService:
                 # https://warthogs.atlassian.net/browse/WD-30487
                 return {
                     "success": False,
-                    "error": "Release branch does not exist. Please create it first.",
+                    "error": "Release branch does not exist. "
+                    "Please create it first.",
                 }
 
             # Merge base branch into release branch to ensure it's up to date
@@ -270,7 +276,8 @@ class ReleasesService:
                 # https://warthogs.atlassian.net/browse/WD-30487
                 return {
                     "success": True,
-                    "message": "File updated successfully. Please create a PR manually.",
+                    "message": "File updated successfully. "
+                    "Please create a PR manually.",
                     "commit": update_result,
                     "branch": RELEASES_BRANCH_NAME,
                 }

--- a/webapp/tests/test_releases_manager.py
+++ b/webapp/tests/test_releases_manager.py
@@ -399,7 +399,7 @@ class TestReleasesGitHubClient:
             result = github_client.merge_base_into_release()
 
         assert result["success"] is True
-        
+
         # Verify the request was made with correct parameters
         call_args = mock_requests["request"].call_args
         assert call_args.args[0] == "POST"
@@ -462,12 +462,12 @@ class TestReleasesGitHubClient:
             "content": {"sha": "new_sha_456"},
             "commit": {"message": "Update releases.yaml"},
         }
-        
+
         # Mock two different responses for GET and PUT
         get_response = MagicMock()
         get_response.status_code = 200
         get_response.json.return_value = {"sha": file_sha}
-        
+
         put_response = MagicMock()
         put_response.status_code = 200
         put_response.json.return_value = commit_response
@@ -508,11 +508,9 @@ class TestReleasesGitHubClient:
     ):
         """Test that content is base64 encoded before sending."""
         import base64
-        
+
         new_content = "test: content"
-        expected_encoded = base64.b64encode(
-            new_content.encode()
-        ).decode()
+        expected_encoded = base64.b64encode(new_content.encode()).decode()
 
         def capture_params(method, url, **kwargs):
             if method == "PUT":
@@ -562,7 +560,7 @@ class TestReleasesGitHubClient:
         ):
             with pytest.raises(GithubError) as exc_info:
                 github_client.update_releases_yaml("content")
-            
+
             assert exc_info.value.status_code == 401
 
 


### PR DESCRIPTION
## Done

 - Created merge_base_into_release and update_release_yaml functions for ReleaseGithubAPI
 - Wrote tests for above functions
 - Groundwork for the entire workflow in releasemanager service.

## QA

### QA steps

 - Run the application locally.
 - Create and use a github token with write permissions to repository.
 - use [this](https://pastebin.canonical.com/p/kJYNSwRPSv/) script to test the functionalities
 - I have tested these functions and resulting commits are here https://github.com/canonical/ubuntu.com/compare/main..._releases_branch
 - Use `sudo dotrun test-python` to run tests.
 
### Note:
- Original plan was to rebase release branch on main but there was no clean way of doing it so I have opted to perform merge instead.

## Fixes

 - Fixes #
 - Fixes [WD-32402](https://warthogs.atlassian.net/browse/WD-32402)

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.


[WD-32402]: https://warthogs.atlassian.net/browse/WD-32402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ