### PR TITLE
WD-32397: Create release branch and PR

### DIFF
--- a/static/client/components/ReleaseForm/ReleaseForm.tsx
+++ b/static/client/components/ReleaseForm/ReleaseForm.tsx
@@ -75,7 +75,7 @@ const ReleaseForm = ({ releases, onCancel }: IReleaseFormProps): ReactNode => {
   const handleSubmit = useCallback(async () => {
     setIsLoading(true);
     try {
-      await ReleasesServices.submitRelease(formData);
+      await ReleasesServices.updateReleases(formData, "Update releases.yaml via ReleaseForm");
       await queryClient.invalidateQueries("releases");
       onCancel();
     } catch {

--- a/static/client/pages/Releases/Releases.tsx
+++ b/static/client/pages/Releases/Releases.tsx
@@ -74,7 +74,7 @@ const Releases = (): ReactNode => {
             </span>
             {status.pr && (
               <a
-                href={String((status.pr as Record<string, unknown>).html_url ?? "#")}
+                href={`https://ubuntu-com-${(status.pr as Record<string, unknown>).number}.demos.haus/`}
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -14,7 +14,7 @@ export const ENDPOINTS = {
   reportBug: "/api/report-bug",
   requestFeature: "/api/request-feature",
   getReleases: "/api/get-releases",
-  submitRelease: "/api/submit-release",
+  updateReleases: "/api/update-releases",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/partials/ReleasesApiClass.ts
+++ b/static/client/services/api/partials/ReleasesApiClass.ts
@@ -8,7 +8,7 @@ export class ReleasesApiClass extends BasicApiClass {
     return this.callApi<{ data: IReleasesResponse }>(ENDPOINTS.getReleases, REST_TYPES.GET);
   }
 
-  public submitRelease(data: IReleasesData): Promise<void> {
-    return this.callApi(ENDPOINTS.submitRelease, REST_TYPES.POST, { releases: data });
+  public updateReleases(data: IReleasesData, commitMessage: string): Promise<void> {
+    return this.callApi(ENDPOINTS.updateReleases, REST_TYPES.POST, { releases: data, commit_message: commitMessage });
   }
 }

--- a/static/client/services/api/services/releases.ts
+++ b/static/client/services/api/services/releases.ts
@@ -5,8 +5,8 @@ export const getReleases = async (): Promise<{ data: IReleasesResponse }> => {
   return api.releases.getReleases();
 };
 
-export const submitRelease = async (data: IReleasesData): Promise<void> => {
-  return api.releases.submitRelease(data);
+export const updateReleases = async (data: IReleasesData, commitMessage: string): Promise<void> => {
+  return api.releases.updateReleases(data, commitMessage);
 };
 
 export * as ReleasesServices from "./releases";

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 
 import flask
@@ -23,10 +24,12 @@ def create_app():
         static_folder="../static",
     )
     app.config.from_pyfile(filename="settings.py")
+    app.json.sort_keys = False
 
     # Allow CORS in development mode
     if os.getenv("FLASK_DEBUG"):
         CORS(app, origins=["*"])
+        logging.getLogger().setLevel(logging.DEBUG)
     else:
         CORS(app, origins=["login.ubuntu.com"])
 

--- a/webapp/releases_manager.py
+++ b/webapp/releases_manager.py
@@ -1,6 +1,7 @@
 import io
 import json
 import base64
+import logging
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
@@ -10,6 +11,19 @@ from ruamel.yaml.scalarstring import (
 )
 
 from webapp.github import ReleasesGitHubAPI, GithubError
+
+logger = logging.getLogger(__name__)
+
+
+class MergeConflictError(GithubError):
+    """Raised when merging base into the release branch produces a conflict."""
+
+    def __init__(self):
+        super().__init__(
+            "Merge conflict detected. Please resolve conflicts manually.",
+            status_code=409,
+        )
+
 
 RELEASES_REPO = "canonical/ubuntu.com"
 # RELEASES_FILE_PATH = "releases.yaml"
@@ -42,7 +56,7 @@ class ReleaseYamlParser:
 
     def _construct_custom_tag(self, loader, tag_suffix, node) -> TaggedField:
         """Extracts custom tagged fields from YAML nodes."""
-        tag_name = node.tag.lstrip("!")
+        tag_name = node.tag.removeprefix("!")
         style = None
 
         if node.id == "scalar":
@@ -73,6 +87,7 @@ class ReleaseYamlParser:
 
     def parse_yaml(self, yaml_content) -> dict:
         """Reads YAML string, parses it, and serializes to JSON."""
+        logger.debug("Parsing YAML content (%d bytes)", len(yaml_content))
         data = self.yaml.load(yaml_content)
         return self._serialize_node(data)
 
@@ -85,7 +100,7 @@ class ReleaseYamlParser:
             return dumper.represent_mapping(tag, data.value)
         return dumper.represent_scalar(tag, str(data.value), style=data.style)
 
-    def _validate_yaml_structure(self, original_data: dict, yaml_str: str):
+    def _validate_yaml_structure(self, expected_data: dict, yaml_str: str):
         """Validates generated YAML by round-tripping it through parse_yaml
         and comparing against the original data.
 
@@ -94,7 +109,8 @@ class ReleaseYamlParser:
             YAMLError: If the generated YAML cannot be parsed.
         """
         roundtrip = self.parse_yaml(yaml_str)
-        if roundtrip != original_data:
+        if roundtrip != expected_data:
+            logger.error("YAML round-trip validation failed")
             raise ValueError(
                 "YAML round-trip validation failed: "
                 "generated YAML does not match the input data."
@@ -170,12 +186,15 @@ class ReleaseYamlParser:
             be parsed during validation.
         """
         data = json.loads(json_content)
+
+        logger.debug("Merging JSON changes into YAML")
         original = self.yaml.load(original_yaml)
         self._deep_merge(original, data)
         stream = io.StringIO()
         self.yaml.dump(original, stream)
         yaml_str = stream.getvalue()
         self._validate_yaml_structure(data, yaml_str)
+        logger.debug("Merge and dump complete (%d bytes)", len(yaml_str))
         return yaml_str
 
 
@@ -207,8 +226,12 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
             if not pr:
                 # TODO: Create a PR for the orphaned branch
                 # https://warthogs.atlassian.net/browse/WD-32397
-                pass
+                logger.warning(
+                    "Release branch %s exists but has no open PR",
+                    RELEASES_BRANCH_NAME,
+                )
 
+        logger.info("Fetching releases YAML from branch: %s", ref)
         yaml_content = self._request("GET", url, params={"ref": ref}, raw=True)
         status = {"pr": pr, "pr_exists": pr is not None, "branch": ref}
         return yaml_content, status
@@ -227,7 +250,9 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         response = self._request("GET", url, params=params)
 
         if response:
+            logger.info("Found existing PR #%s", response[0]["number"])
             return response[0]  # Return the first matching PR
+        logger.debug("No open PR found for branch: %s", RELEASES_BRANCH_NAME)
 
     def fetch_releases_branch(self) -> dict | None:
         """Fetches the status of the releases branch.
@@ -239,24 +264,23 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         url = f"repos/{self.repo}/branches/{RELEASES_BRANCH_NAME}"
         try:
             response = self._request("GET", url)
+            logger.debug("Release branch exists: %s", RELEASES_BRANCH_NAME)
             return response
         except GithubError as e:
             if e.status_code == 404:
+                logger.debug(
+                    "Release branch does not exist: %s", RELEASES_BRANCH_NAME
+                )
                 return None
             raise
 
-    def merge_base_into_release(self) -> dict | None:
-        """Merge base branch into the release branch if there are no conflicts.
-
-        Returns:
-            dict: Result of merge operation.
-            None: If the branch does not exist.
+    def merge_base_into_release(self) -> None:
+        """Merge base branch into the release branch.
 
         Raises:
+            MergeConflictError: If there is a merge conflict.
             GithubError: If the merge operation fails for other reasons.
         """
-        if not self.fetch_releases_branch():
-            return None
 
         url = f"repos/{self.repo}/merges"
         payload = {
@@ -266,16 +290,20 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
             f" into {RELEASES_BRANCH_NAME}",
         }
 
+        logger.info(
+            "Merging %s into %s", BASE_BRANCH_NAME, RELEASES_BRANCH_NAME
+        )
         try:
-            response = self._request("POST", url, data=payload, raw=True)
-            return {"success": True, "merge": response}
+            self._request("POST", url, data=payload, raw=True)
+            logger.info("Merge complete")
         except GithubError as e:
             if e.status_code == 409:
-                return {
-                    "success": False,
-                    "error": "Merge conflict detected."
-                    " Please resolve conflicts manually.",
-                }
+                logger.warning(
+                    "Merge conflict detected between %s and %s",
+                    BASE_BRANCH_NAME,
+                    RELEASES_BRANCH_NAME,
+                )
+                raise MergeConflictError()
             raise
 
     def update_releases_yaml(
@@ -304,8 +332,13 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
                 "GET", url, params={"ref": RELEASES_BRANCH_NAME}
             )
             file_sha = current_file["sha"]
+            logger.debug("Existing file SHA: %s", file_sha)
         except GithubError as e:
             if e.status_code == 404:
+                logger.debug(
+                    "File not found on branch %s, will create it",
+                    RELEASES_BRANCH_NAME,
+                )
                 file_sha = None
             else:
                 raise
@@ -324,6 +357,58 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
 
         # Update the file
         response = self._request("PUT", url, data=payload)
+        return response
+
+    def _get_branch_sha(self, branch_name: str) -> str:
+        """Returns the latest commit SHA for the given branch.
+
+        Raises:
+            GithubError: If the branch does not exist or the request fails.
+        """
+        url = f"repos/{self.repo}/branches/{branch_name}"
+        response = self._request("GET", url)
+        return response["commit"]["sha"]
+
+    def create_releases_branch(self) -> dict:
+        """Creates the releases branch from the base branch.
+
+        Returns:
+            dict: The branch creation response data.
+        Raises:
+            GithubError: If the branch creation operation fails.
+        """
+        logger.info("Creating release branch: %s", RELEASES_BRANCH_NAME)
+        url = f"repos/{self.repo}/git/refs"
+        payload = {
+            "ref": f"refs/heads/{RELEASES_BRANCH_NAME}",
+            "sha": self._get_branch_sha(BASE_BRANCH_NAME),
+        }
+        response = self._request("POST", url, data=payload)
+        logger.info("Release branch created: %s", RELEASES_BRANCH_NAME)
+        return response
+
+    def create_releases_pr(self) -> dict:
+        """Creates a pull request for the releases branch.
+
+        Returns:
+            dict: The PR creation response data.
+        Raises:
+            GithubError: If the PR creation operation fails.
+        """
+        logger.info(
+            "Creating PR for branch: %s -> %s",
+            RELEASES_BRANCH_NAME,
+            BASE_BRANCH_NAME,
+        )
+        url = f"repos/{self.repo}/pulls"
+        payload = {
+            "title": "Update releases.yaml",
+            "head": RELEASES_BRANCH_NAME,
+            "base": BASE_BRANCH_NAME,
+            "body": "Automated update of releases.yaml",
+        }
+        response = self._request("POST", url, data=payload)
+        logger.info("PR created: #%s", response.get("number"))
         return response
 
 
@@ -360,60 +445,33 @@ class ReleasesService:
             A dictionary with the update status and any relevant information.
         """
 
-        original_yaml, _ = self.github_client.fetch_releases_yaml()
+        logger.info("Starting releases update workflow")
+        original_yaml, status = self.github_client.fetch_releases_yaml()
         yaml_content = self.parser.merge_and_dump(original_yaml, json_content)
-
-        with open("debug_merged.yaml", "w") as f:
-            f.write(yaml_content)
-
-        try:
-            branch = self.github_client.fetch_releases_branch()
-            if not branch:
-                # TODO: Create the branch from base branch if it doesn't exist
-                # https://warthogs.atlassian.net/browse/WD-30487
-                return {
-                    "success": False,
-                    "error": "Release branch does not exist. "
-                    "Please create it first.",
-                }
-
+        branch_exists = status["branch"] == RELEASES_BRANCH_NAME
+        if not branch_exists:
+            self.github_client.create_releases_branch()
+        else:
             # Merge base branch into release branch to ensure it's up to date
-            merge_result = self.github_client.merge_base_into_release()
-            if not merge_result.get("success"):
-                return merge_result
+            self.github_client.merge_base_into_release()
 
-            update_result = self.github_client.update_releases_yaml(
-                yaml_content, commit_message
-            )
+        update_result = self.github_client.update_releases_yaml(
+            yaml_content, commit_message
+        )
 
-            # Check if PR exists
-            pr = self.github_client.fetch_releases_pr()
+        pr = status["pr"] or self.github_client.create_releases_pr()
+        logger.info(
+            "Releases update complete. PR: #%s (%s)",
+            pr.get("number"),
+            pr.get("html_url"),
+        )
 
-            if not pr:
-                # TODO: Create PR automatically
-                # https://warthogs.atlassian.net/browse/WD-30487
-                return {
-                    "success": True,
-                    "message": "File updated successfully. "
-                    "Please create a PR manually.",
-                    "commit": update_result,
-                    "branch": RELEASES_BRANCH_NAME,
-                }
-
-            return {
-                "success": True,
-                "message": "releases.yaml updated successfully.",
-                "commit": update_result,
-                "pr": {
-                    "number": pr.get("number"),
-                    "url": pr.get("html_url"),
-                    "title": pr.get("title"),
-                },
-            }
-
-        except GithubError as e:
-            return {
-                "success": False,
-                "error": str(e),
-                "status_code": e.status_code,
-            }
+        return {
+            "message": "releases.yaml updated successfully.",
+            "commit": update_result,
+            "pr": {
+                "number": pr.get("number"),
+                "url": pr.get("html_url"),
+                "title": pr.get("title"),
+            },
+        }

--- a/webapp/releases_manager.py
+++ b/webapp/releases_manager.py
@@ -1,5 +1,13 @@
+import io
+import json
+import base64
+
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import (
+    DoubleQuotedScalarString,
+    SingleQuotedScalarString,
+)
 
 from webapp.github import ReleasesGitHubAPI, GithubError
 
@@ -13,9 +21,10 @@ BASE_BRANCH_NAME = "main"
 class TaggedField:
     """Wrapper class to hold data & tag information in memory."""
 
-    def __init__(self, value, tag_type):
+    def __init__(self, value, tag_type, style=None):
         self.value = value
         self.tag_type = tag_type
+        self.style = style  # Scalar quote style: '"', "'", or None (plain)
 
 
 class ReleaseYamlParser:
@@ -23,24 +32,30 @@ class ReleaseYamlParser:
 
     def __init__(self):
         self.yaml = YAML(typ="rt")
+        self.yaml.preserve_quotes = True
         self.yaml.constructor.add_multi_constructor(
             "", self._construct_custom_tag
+        )
+        self.yaml.representer.add_representer(
+            TaggedField, self._represent_tagged_field
         )
 
     def _construct_custom_tag(self, loader, tag_suffix, node) -> TaggedField:
         """Extracts custom tagged fields from YAML nodes."""
         tag_name = node.tag.lstrip("!")
+        style = None
 
         if node.id == "scalar":
             value = loader.construct_scalar(node)
+            style = node.style
         elif node.id == "mapping":
             maptyp = CommentedMap()
             loader.construct_mapping(node, maptyp, deep=True)
-            value = dict(maptyp)
+            value = maptyp
         else:
             value = None
 
-        return TaggedField(value, tag_name)
+        return TaggedField(value, tag_name, style=style)
 
     def _serialize_node(self, node) -> dict:
         """Transforms Python dicts into JSON compatible format recursively."""
@@ -60,6 +75,108 @@ class ReleaseYamlParser:
         """Reads YAML string, parses it, and serializes to JSON."""
         data = self.yaml.load(yaml_content)
         return self._serialize_node(data)
+
+    def _represent_tagged_field(self, dumper, data: TaggedField):
+        """Representer for TaggedField: emits
+        custom YAML tags (!date, !link, !image)."""
+
+        tag = f"!{data.tag_type}"
+        if isinstance(data.value, dict):
+            return dumper.represent_mapping(tag, data.value)
+        return dumper.represent_scalar(tag, str(data.value), style=data.style)
+
+    def _validate_yaml_structure(self, original_data: dict, yaml_str: str):
+        """Validates generated YAML by round-tripping it through parse_yaml
+        and comparing against the original data.
+
+        Raises:
+            ValueError: If the round-tripped data does not match the original.
+            YAMLError: If the generated YAML cannot be parsed.
+        """
+        roundtrip = self.parse_yaml(yaml_str)
+        if roundtrip != original_data:
+            raise ValueError(
+                "YAML round-trip validation failed: "
+                "generated YAML does not match the input data."
+            )
+
+    def _is_dynamic_scalar_map(self, d):
+        """True if all keys and values
+        are plain scalars (no nested structures).
+
+        Used to identify checksum data
+        """
+        return bool(d) and all(
+            not isinstance(k, (dict, TaggedField, CommentedMap))
+            and not isinstance(v, (dict, TaggedField, CommentedMap))
+            for k, v in d.items()
+        )
+
+    def _deep_merge(self, original, json_node: dict):
+        """Merges json_node changes onto a RT-loaded CommentedMap in place.
+
+        Leaf dicts (where all values are scalars, e.g. checksum sections) are
+        replaced wholesale — keys can be added, removed, or updated.
+        """
+
+        for key, original_value in original.items():
+            if key not in json_node:
+                continue
+
+            updated_value = json_node[key]
+
+            if isinstance(original_value, TaggedField):
+                if isinstance(original_value.value, (dict, TaggedField)):
+                    self._deep_merge(
+                        original_value.value, updated_value["value"]
+                    )
+                else:
+                    original_value.value = type(original_value.value)(
+                        updated_value["value"]
+                    )
+
+            elif isinstance(original_value, dict):
+                if self._is_dynamic_scalar_map(original_value):
+                    old_key_types = {str(k): type(k) for k in original_value}
+                    old_val_types = {
+                        str(k): type(v) for k, v in original_value.items()
+                    }
+                    original_value.clear()
+                    for k, v in updated_value.items():
+                        key_type = old_key_types.get(
+                            k, DoubleQuotedScalarString
+                        )
+                        val_type = old_val_types.get(
+                            k, DoubleQuotedScalarString
+                        )
+                        original_value[key_type(k)] = val_type(v)
+                else:
+                    self._deep_merge(original_value, updated_value)
+
+            elif isinstance(
+                original_value,
+                (DoubleQuotedScalarString, SingleQuotedScalarString, str, int),
+            ):
+                original[key] = type(original_value)(updated_value)
+
+    def merge_and_dump(self, original_yaml: str, json_content: str) -> str:
+        """
+        Merges changes from JSON content onto the original YAML structure
+        to preserve formatting and style
+
+        Raises:
+            ValueError: If round-trip validation fails.
+            YAMLError: If the generated YAML cannot
+            be parsed during validation.
+        """
+        data = json.loads(json_content)
+        original = self.yaml.load(original_yaml)
+        self._deep_merge(original, data)
+        stream = io.StringIO()
+        self.yaml.dump(original, stream)
+        yaml_str = stream.getvalue()
+        self._validate_yaml_structure(data, yaml_str)
+        return yaml_str
 
 
 class ReleasesGitHubClient(ReleasesGitHubAPI):
@@ -178,7 +295,6 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         Raises:
             GithubError: If the update operation fails.
         """
-        import base64
 
         url = f"repos/{self.repo}/contents/{self.file_path}"
 
@@ -197,17 +313,17 @@ class ReleasesGitHubClient(ReleasesGitHubAPI):
         # Encode the new content in base64
         encoded_content = base64.b64encode(new_content.encode()).decode()
 
-        params = {
+        payload = {
             "message": commit_message,
             "content": encoded_content,
             "branch": RELEASES_BRANCH_NAME,
         }
 
         if file_sha:
-            params["sha"] = file_sha
+            payload["sha"] = file_sha
 
         # Update the file
-        response = self._request("PUT", url, data=params)
+        response = self._request("PUT", url, data=payload)
         return response
 
 
@@ -244,9 +360,11 @@ class ReleasesService:
             A dictionary with the update status and any relevant information.
         """
 
-        # need to convert json content that we get from the parser back
-        # to yaml string before sending to github client
-        yaml_content = json_content
+        original_yaml, _ = self.github_client.fetch_releases_yaml()
+        yaml_content = self.parser.merge_and_dump(original_yaml, json_content)
+
+        with open("debug_merged.yaml", "w") as f:
+            f.write(yaml_content)
 
         try:
             branch = self.github_client.fetch_releases_branch()

--- a/webapp/routes/releases.py
+++ b/webapp/routes/releases.py
@@ -5,7 +5,7 @@ from flask_pydantic import validate
 from ruamel.yaml import YAMLError
 
 from webapp.github import GithubError
-from webapp.releases_manager import ReleasesService
+from webapp.releases_manager import MergeConflictError, ReleasesService
 from webapp.schemas import UpdateReleasesRequest
 from webapp.sso import login_required
 
@@ -54,27 +54,18 @@ def update_releases_yaml(body: UpdateReleasesRequest):
             json.dumps(body.releases), body.commit_message
         )
     except (ValueError, YAMLError) as e:
-        return Response(
-            response=json.dumps(
-                {
-                    "error": "Invalid releases data",
-                    "details": str(e),
-                }
-            ),
-            status=400,
-            mimetype="application/json",
+        return (
+            jsonify({"message": "Invalid releases data", "details": str(e)}),
+            400,
         )
+    except MergeConflictError as e:
+        return jsonify({"message": str(e)}), 409
     except GithubError as e:
-        return Response(
-            response=json.dumps(
-                {
-                    "error": "Failed to update releases",
-                    "details": str(e),
-                }
+        return (
+            jsonify(
+                {"message": "Failed to update releases", "details": str(e)}
             ),
-            status=500,
-            mimetype="application/json",
+            500,
         )
 
-    status_code = 200 if result.get("success") else 400
-    return jsonify(result), status_code
+    return jsonify(result), 200

--- a/webapp/routes/releases.py
+++ b/webapp/routes/releases.py
@@ -47,7 +47,7 @@ def get_releases_yaml():
     methods=["POST"],
 )
 @validate()
-# @login_required
+@login_required
 def update_releases_yaml(body: UpdateReleasesRequest):
     try:
         result = releases_service.update_releases_workflow(

--- a/webapp/routes/releases.py
+++ b/webapp/routes/releases.py
@@ -1,13 +1,17 @@
 import json
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, jsonify
+from flask_pydantic import validate
 from ruamel.yaml import YAMLError
 
-from webapp.releases_manager import ReleasesService
 from webapp.github import GithubError
+from webapp.releases_manager import ReleasesService
+from webapp.schemas import UpdateReleasesRequest
 from webapp.sso import login_required
 
 releases_blueprint = Blueprint("releases", __name__, url_prefix="/api")
+
+releases_service = ReleasesService()
 
 
 @releases_blueprint.route(
@@ -17,8 +21,7 @@ releases_blueprint = Blueprint("releases", __name__, url_prefix="/api")
 @login_required
 def get_releases_yaml():
     try:
-        service = ReleasesService()
-        data = service.get_releases_data()
+        data = releases_service.get_releases_data()
     except (YAMLError, GithubError) as e:
         return Response(
             response=json.dumps(
@@ -37,3 +40,41 @@ def get_releases_yaml():
     )
     response.cache_control.no_store = True
     return response
+
+
+@releases_blueprint.route(
+    "/update-releases",
+    methods=["POST"],
+)
+@validate()
+# @login_required
+def update_releases_yaml(body: UpdateReleasesRequest):
+    try:
+        result = releases_service.update_releases_workflow(
+            json.dumps(body.releases), body.commit_message
+        )
+    except (ValueError, YAMLError) as e:
+        return Response(
+            response=json.dumps(
+                {
+                    "error": "Invalid releases data",
+                    "details": str(e),
+                }
+            ),
+            status=400,
+            mimetype="application/json",
+        )
+    except GithubError as e:
+        return Response(
+            response=json.dumps(
+                {
+                    "error": "Failed to update releases",
+                    "details": str(e),
+                }
+            ),
+            status=500,
+            mimetype="application/json",
+        )
+
+    status_code = 200 if result.get("success") else 400
+    return jsonify(result), status_code

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -109,3 +109,8 @@ class RequestFeatureModel(BaseModel):
     description: str = ""
     summary: str = ""
     objective: str = ""
+
+
+class UpdateReleasesRequest(BaseModel):
+    releases: dict
+    commit_message: str = "Update releases.yaml"

--- a/webapp/tests/test_gdrive.py
+++ b/webapp/tests/test_gdrive.py
@@ -68,7 +68,14 @@ def mock_gdrive(monkeypatch):
     )
 
 
-def test_app_starts_without_gdrive():
+def test_app_starts_without_gdrive(monkeypatch):
+    def raise_build_error(*args, **kwargs):
+        raise ValueError("Invalid Google credentials")
+
+    monkeypatch.setattr(
+        "webapp.gdrive.GoogleDriveClient._build_service",
+        raise_build_error,
+    )
     app = create_app()
     assert "gdrive" not in app.config
 

--- a/webapp/tests/test_releases_manager.py
+++ b/webapp/tests/test_releases_manager.py
@@ -6,6 +6,7 @@ from webapp.releases_manager import (
     ReleaseYamlParser,
     ReleasesGitHubClient,
     ReleasesService,
+    MergeConflictError,
 )
 from webapp.github import GithubError
 
@@ -190,7 +191,7 @@ class TestReleasesGitHubClient:
         self, github_client, mock_requests
     ):
         """Test that fetch_releases_pr returns PR data when a PR exists."""
-        pr_data = {"pr_id": 123, "title": "Release updates"}
+        pr_data = {"number": 123, "title": "Release updates"}
         mock_requests["response"].json.return_value = [pr_data]
 
         result = github_client.fetch_releases_pr()
@@ -382,23 +383,12 @@ class TestReleasesGitHubClient:
         self, github_client, mock_requests
     ):
         """Test successful merge when branch exists."""
-        branch_data = {
-            "pr_name": "_releases_branch",
-            "commit": {"sha": "abc123"},
-        }
-        merge_response = {
-            "sha": "merge123",
-            "commit": {"message": "Merge main into _releases_branch"},
-        }
-        mock_requests["response"].json.return_value = merge_response
+        mock_requests["response"].text = "ok"
         mock_requests["response"].status_code = 201
 
-        with patch.object(
-            github_client, "fetch_releases_branch", return_value=branch_data
-        ):
-            result = github_client.merge_base_into_release()
+        result = github_client.merge_base_into_release()
 
-        assert result["success"] is True
+        assert result is None
 
         # Verify the request was made with correct parameters
         call_args = mock_requests["request"].call_args
@@ -408,10 +398,8 @@ class TestReleasesGitHubClient:
     def test_merge_base_into_release_returns_none_when_no_branch(
         self, github_client
     ):
-        """Test that merge returns None when branch doesn't exist."""
-        with patch.object(
-            github_client, "fetch_releases_branch", return_value=None
-        ):
+        """Test that merge still runs without checking branch first."""
+        with patch.object(github_client, "_request", return_value="ok"):
             result = github_client.merge_base_into_release()
 
         assert result is None
@@ -419,21 +407,12 @@ class TestReleasesGitHubClient:
     def test_merge_base_into_release_handles_conflict(
         self, github_client, mock_requests
     ):
-        """Test merge returns error dict when conflict is detected (409)."""
-        branch_data = {
-            "pr_name": "_releases_branch",
-            "commit": {"sha": "abc123"},
-        }
+        """Test merge raises MergeConflictError when conflict is detected."""
         mock_requests["response"].status_code = 409
         mock_requests["response"].text = "Merge conflict"
 
-        with patch.object(
-            github_client, "fetch_releases_branch", return_value=branch_data
-        ):
-            result = github_client.merge_base_into_release()
-
-        assert result["success"] is False
-        assert "conflict" in result["error"].lower()
+        with pytest.raises(MergeConflictError):
+            github_client.merge_base_into_release()
 
     def test_merge_base_into_release_raises_on_other_errors(
         self, github_client, mock_requests


### PR DESCRIPTION
## Done

 - Creates and manages the releases branch from the base branch when it does not exist
 - Creates a GitHub PR for the releases branch automatically
 - Added logging throughout `releases_manager.py` for observability (INFO for key workflow steps, WARNING for merge conflicts/orphaned branches, DEBUG for internal state)

## QA

- Run content system locally
- Make changes to the release data from the UI and submit
- If release branch exists, if will create the commit and PR
- Else release branch is created and a PR is opened in ubuntu.com
- Verify the demo link points to `https://ubuntu-com-<pr-number>.demos.haus/`
- An example for same https://github.com/canonical/ubuntu.com/pull/16167 ( I have edited release branch to be `_releases_branch_3` in the code).

### QA steps

 - Set `FLASK_DEBUG=1` and confirm debug logs appear in the output
 - Unset `FLASK_DEBUG` and confirm only INFO+ logs appear

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-32397