### PR TITLE
feat: implement page statistics dashboard

### DIFF
--- a/.env
+++ b/.env
@@ -31,3 +31,6 @@ BAU_BOT_WEBHOOK_URL=webhook_id
 SSO_CLIENT_ID=client-id
 SSO_CLIENT_SECRET=client-secret
 OIDC_PROVIDER=oidc-provider-url
+
+# Page stats
+PAGE_STATS_DOC=google-sheets-url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "postgres"]
+      test: ["CMD-SHELL", "pg_isready -d postgres -U postgres"]
       interval: 1s
       timeout: 3s
       retries: 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-slugify==8.0.4
 black==25.1.0
 flake8==7.1.1
 Authlib==1.6.6
+gspread==6.2.1

--- a/static/client/components/Common/IconTextWithTooltip.tsx
+++ b/static/client/components/Common/IconTextWithTooltip.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 
 import { Tooltip } from "@canonical/react-components";
+import type { Position } from "@canonical/react-components/dist/components/Tooltip/Tooltip";
 
 interface IIconTextWithTooltipProps {
   text?: string;
   icon?: string;
   message?: string | Array<string>;
+  position?: Position;
 }
 
-const IconTextWithTooltip: React.FC<IIconTextWithTooltipProps> = ({ text, icon, message }) => {
+const IconTextWithTooltip: React.FC<IIconTextWithTooltipProps> = ({ text, icon, message, position }) => {
   return (
-    <Tooltip message={Array.isArray(message) ? message.join("\n") : message} zIndex={999}>
-      <span className="u-has-icon">
-        {text}&nbsp;
+    <Tooltip message={Array.isArray(message) ? message.join("\n") : message} position={position} zIndex={999}>
+      <span className="u-has-icon" tabIndex={0}>
+        {text}
         {icon && <i className={`p-icon--${icon}`} />}
       </span>
     </Tooltip>

--- a/static/client/components/Common/IconTextWithTooltip.tsx
+++ b/static/client/components/Common/IconTextWithTooltip.tsx
@@ -5,12 +5,12 @@ import { Tooltip } from "@canonical/react-components";
 interface IIconTextWithTooltipProps {
   text?: string;
   icon?: string;
-  message?: string;
+  message?: string | Array<string>;
 }
 
 const IconTextWithTooltip: React.FC<IIconTextWithTooltipProps> = ({ text, icon, message }) => {
   return (
-    <Tooltip message={message} zIndex={999}>
+    <Tooltip message={Array.isArray(message) ? message.join("\n") : message} zIndex={999}>
       <span className="u-has-icon">
         {text}&nbsp;
         {icon && <i className={`p-icon--${icon}`} />}

--- a/static/client/components/JiraTasks/JiraTasks.tsx
+++ b/static/client/components/JiraTasks/JiraTasks.tsx
@@ -35,14 +35,14 @@ const JiraTasks = ({ tasks, isWebPage }: IJiraTasksProps): ReactNode => {
         </tr>
       </thead>
       <tbody>
-        {tasks.map((task) => (
+        {tasks?.map((task) => (
           <tr>
             <td colSpan={3}>{task.summary}</td>
             <td>Copy update</td>
             <td className={getStatusClass(task.status)}>
               {task.status.charAt(0).toUpperCase() + task.status.slice(1).toLowerCase()}
             </td>
-            <td>{DatesServices.beatifyDate(task.created_at)}</td>
+            <td>{DatesServices.beautifyDate(task.created_at)}</td>
             <td>
               <a href={`${config.jiraTaskLink}${task.jira_id}`} rel="noreferrer" target="_blank">
                 {task.jira_id}
@@ -50,7 +50,7 @@ const JiraTasks = ({ tasks, isWebPage }: IJiraTasksProps): ReactNode => {
             </td>
           </tr>
         ))}
-        {tasks.length === 0 && isWebPage && (
+        {tasks?.length === 0 && isWebPage && (
           <tr>
             <td colSpan={3}>
               <p>

--- a/static/client/components/Webpage/WebpageDetails.tsx
+++ b/static/client/components/Webpage/WebpageDetails.tsx
@@ -27,7 +27,7 @@ const WebpageDetails = ({ page, project }: IWebpageDetailsProps) => {
     <>
       <div className="l-webpage__details-header">
         <h2 className="p-text--small-caps">Page Details</h2>
-        <Button appearance="base" hasIcon>
+        <Button appearance="base" className="u-no-margin" hasIcon small>
           <i className="p-icon--edit" />
         </Button>
       </div>
@@ -40,18 +40,20 @@ const WebpageDetails = ({ page, project }: IWebpageDetailsProps) => {
         </div>
 
         <div className="label u-text--muted">
-          <IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} text="Owner" />
+          Owner
+          <IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} />
         </div>
         <div className="value">{page.owner.name}</div>
 
         <div className="label u-text--muted">
-          <IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} text="Contributors" />
+          Contributors
+          <IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} />
         </div>
         <div className="value">{page.reviewers.map((r) => r.name).join(", ")}</div>
 
         <div className="label u-text--muted">Related links</div>
         <div className="value">
-          <ul className="p-inline-list--middot">
+          <ul className="p-inline-list--middot u-no-margin">
             {page.copy_doc_link && (
               <li className="p-inline-list__item">
                 <Button appearance="link" className="u-no-margin--bottom" onClick={openCopyDoc}>

--- a/static/client/components/Webpage/WebpageDetails.tsx
+++ b/static/client/components/Webpage/WebpageDetails.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@canonical/react-components";
+
+import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
+import config from "@/config";
+import type { IPage } from "@/services/api/types/pages";
+
+interface IWebpageDetailsProps {
+  page: IPage;
+  project: string;
+}
+
+const WebpageDetails = ({ page, project }: IWebpageDetailsProps) => {
+  const pageExtension = page.ext || ".html";
+
+  const openCopyDoc = () => window.open(page.copy_doc_link);
+
+  const openGitHub = () => {
+    if (page.children?.length) {
+      window.open(`${config.ghLink(project)}${page.name}/index${pageExtension}`);
+    } else {
+      window.open(`${config.ghLink(project)}${page.name}${pageExtension}`);
+    }
+  };
+
+  const openFigma = () => window.open(page.figma_link);
+  return (
+    <>
+      <div className="l-webpage__details-header">
+        <h2 className="p-text--small-caps">Page Details</h2>
+        <Button appearance="base" hasIcon>
+          <i className="p-icon--edit" />
+        </Button>
+      </div>
+      <div className="l-webpage__details">
+        <div className="label u-text--muted">Published page</div>
+        <div className="value">
+          <a href={`https://${project}${page.url}`} rel="noopener noreferrer" target="_blank">
+            View live page <i className="p-icon--external-link" />
+          </a>
+        </div>
+
+        <div className="label u-text--muted">
+          <IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} text="Owner" />
+        </div>
+        <div className="value">{page.owner.name}</div>
+
+        <div className="label u-text--muted">
+          <IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} text="Contributors" />
+        </div>
+        <div className="value">{page.reviewers.map((r) => r.name).join(", ")}</div>
+
+        <div className="label u-text--muted">Related links</div>
+        <div className="value">
+          <ul className="p-inline-list--middot">
+            {page.copy_doc_link && (
+              <li className="p-inline-list__item">
+                <Button appearance="link" className="u-no-margin--bottom" onClick={openCopyDoc}>
+                  Copy doc <i className="p-icon--external-link" />
+                </Button>
+              </li>
+            )}
+            <li className="p-inline-list__item">
+              <Button appearance="link" className="u-no-margin--bottom" onClick={openGitHub}>
+                Github <i className="p-icon--external-link" />
+              </Button>
+            </li>
+            {page.figma_link && (
+              <li className="p-inline-list__item">
+                <Button appearance="link" className="u-no-margin--bottom" onClick={openFigma}>
+                  Figma <i className="p-icon--external-link" />
+                </Button>
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default WebpageDetails;

--- a/static/client/components/Webpage/WebpageStats.tsx
+++ b/static/client/components/Webpage/WebpageStats.tsx
@@ -37,7 +37,7 @@ const WebpageStats = ({ url, project }: IWebpageStatsProps) => {
 
         <div className="label u-text--muted">
           Prohibited words
-          {statsData.copy_errors > 0 && (
+          {typeof statsData.copy_errors === "number" && statsData.copy_errors > 0 && (
             <IconTextWithTooltip icon="information" message={isLoading ? "" : statsData.prohibited_words} />
           )}
         </div>

--- a/static/client/components/Webpage/WebpageStats.tsx
+++ b/static/client/components/Webpage/WebpageStats.tsx
@@ -20,13 +20,15 @@ const WebpageStats = ({ url, project }: IWebpageStatsProps) => {
 
         <div className="label u-text--muted">
           Readability score
-          <IconTextWithTooltip icon="information" message={config.tooltips.readability} />
+          {statsData.readability_score !== "N/A" && (
+            <IconTextWithTooltip icon="information" message={config.tooltips.readability} />
+          )}
         </div>
         <div className="value">{isLoading ? "Loading..." : statsData.readability_score}</div>
 
         <div className="label u-text--muted">
           Accessibility score
-          <IconTextWithTooltip icon="information" message={config.tooltips.accessibility} />
+          <IconTextWithTooltip icon="information" message={config.tooltips.accessibility} position="top-left" />
         </div>
         <div className="value">{isLoading ? "Loading..." : statsData.accessibility_score}</div>
 
@@ -35,7 +37,9 @@ const WebpageStats = ({ url, project }: IWebpageStatsProps) => {
 
         <div className="label u-text--muted">
           Prohibited words
-          <IconTextWithTooltip icon="information" message={isLoading ? "" : statsData.prohibited_words} />
+          {statsData.copy_errors > 0 && (
+            <IconTextWithTooltip icon="information" message={isLoading ? "" : statsData.prohibited_words} />
+          )}
         </div>
         <div className="value">{isLoading ? "Loading..." : statsData.copy_errors}</div>
       </div>

--- a/static/client/components/Webpage/WebpageStats.tsx
+++ b/static/client/components/Webpage/WebpageStats.tsx
@@ -8,8 +8,17 @@ interface IWebpageStatsProps {
   project: string;
 }
 
+const EMPTY_STATS: IPageStats["data"] = {
+  last_updated: "N/A",
+  readability_score: "N/A",
+  accessibility_score: "N/A",
+  link_count: "N/A",
+  prohibited_words: "N/A",
+  copy_errors: "N/A",
+};
+
 const WebpageStats = ({ url, project }: IWebpageStatsProps) => {
-  const { data: statsData = {} as IPageStats["data"], isLoading } = useWebpageStats(url, project);
+  const { data: statsData = EMPTY_STATS, isLoading } = useWebpageStats(url, project);
 
   return (
     <>

--- a/static/client/components/Webpage/WebpageStats.tsx
+++ b/static/client/components/Webpage/WebpageStats.tsx
@@ -1,0 +1,46 @@
+import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
+import config from "@/config";
+import { useWebpageStats } from "@/services/api/hooks/stats";
+import type { IPageStats } from "@/services/api/types/pages";
+
+interface IWebpageStatsProps {
+  url: string;
+  project: string;
+}
+
+const WebpageStats = ({ url, project }: IWebpageStatsProps) => {
+  const { data: statsData = {} as IPageStats["data"], isLoading } = useWebpageStats(url, project);
+
+  return (
+    <>
+      <h2 className="p-text--small-caps">Page Stats</h2>
+      <div className="l-webpage__details">
+        <div className="label u-text--muted">Last updated</div>
+        <div className="value">{isLoading ? "Loading..." : statsData.last_updated}</div>
+
+        <div className="label u-text--muted">
+          Readability score
+          <IconTextWithTooltip icon="information" message={config.tooltips.readability} />
+        </div>
+        <div className="value">{isLoading ? "Loading..." : statsData.readability_score}</div>
+
+        <div className="label u-text--muted">
+          Accessibility score
+          <IconTextWithTooltip icon="information" message={config.tooltips.accessibility} />
+        </div>
+        <div className="value">{isLoading ? "Loading..." : statsData.accessibility_score}</div>
+
+        <div className="label u-text--muted">Link count</div>
+        <div className="value">{isLoading ? "Loading..." : statsData.link_count}</div>
+
+        <div className="label u-text--muted">
+          Prohibited words
+          <IconTextWithTooltip icon="information" message={isLoading ? "" : statsData.prohibited_words} />
+        </div>
+        <div className="value">{isLoading ? "Loading..." : statsData.copy_errors}</div>
+      </div>
+    </>
+  );
+};
+
+export default WebpageStats;

--- a/static/client/components/WebpageAssets/index.tsx
+++ b/static/client/components/WebpageAssets/index.tsx
@@ -29,33 +29,32 @@ const WebpageAssets: React.FC<WebpageAssetsProps> = ({ url = "", projectName = "
   if (!assetsData?.assets?.length) return null;
 
   return (
-    <div id="webpage-assets">
-      <section>
-        <h2 className="p-text--small-caps u-sv1">Assets used</h2>
-        <div className="grid-row--25-25-25-25">
-          {assetsData.assets?.map((asset) => {
-            return (
-              <div className="grid-col" key={asset.id}>
-                <Asset asset={asset} />
-              </div>
-            );
-          })}
-        </div>
-        {assetsData.total > assetsData.page_size && (
-          <TablePagination
-            currentPage={assetsData.page}
-            data={assetsData.assets}
-            description={`Showing ${Math.min(assetsData.page * assetsData.page_size, assetsData.total)} out of ${assetsData.total} assets`}
-            externallyControlled
-            onPageChange={paginate}
-            onPageSizeChange={handlePageSizeChange}
-            pageLimits={[4]}
-            pageSize={assetsData.page_size}
-            totalItems={assetsData.total}
-          />
-        )}
-      </section>
-    </div>
+    <section id="webpage-assets">
+      <hr className="p-rule" />
+      <h2 className="p-text--small-caps u-sv1">Assets used</h2>
+      <div className="grid-row--25-25-25-25">
+        {assetsData.assets?.map((asset) => {
+          return (
+            <div className="grid-col" key={asset.id}>
+              <Asset asset={asset} />
+            </div>
+          );
+        })}
+      </div>
+      {assetsData.total > assetsData.page_size && (
+        <TablePagination
+          currentPage={assetsData.page}
+          data={assetsData.assets}
+          description={`Showing ${Math.min(assetsData.page * assetsData.page_size, assetsData.total)} out of ${assetsData.total} assets`}
+          externallyControlled
+          onPageChange={paginate}
+          onPageSizeChange={handlePageSizeChange}
+          pageLimits={[4]}
+          pageSize={assetsData.page_size}
+          totalItems={assetsData.total}
+        />
+      )}
+    </section>
   );
 };
 

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -39,6 +39,8 @@ const config = {
       "Replacing or removing logos or images",
     ],
     pageRefreshes: ["Changing or adding to the page layout", "Modifications that change the layout"],
+    readability: "Aim for a score of 7 on most pages.",
+    accessibility: "If your score is 89 or lower, there are likely quick fixes to improve accessibility.",
   },
   assetsManagerUrl: "https://assets.ubuntu.com/manager",
   api: {

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -40,7 +40,7 @@ const config = {
     ],
     pageRefreshes: ["Changing or adding to the page layout", "Modifications that change the layout"],
     readability: "Aim for a score of 7 on most pages.",
-    accessibility: "If your score is 89 or lower, there are likely quick fixes to improve accessibility.",
+    accessibility: "Improve accessibility with quick fixes for scores under 90",
   },
   assetsManagerUrl: "https://assets.ubuntu.com/manager",
   api: {

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -16,8 +16,8 @@ import { usePanelsStore } from "@/store/app";
 
 const Webpage = ({ page, project }: IWebpageProps): ReactNode => {
   const toggleProductsPanel = usePanelsStore((state) => state.toggleProductsPanel);
-  const isNew = useMemo(() => page.status === PageStatus.NEW, [page]);
-  const pageName = useMemo(() => page.name.split("/").reverse()[0], [page]);
+  const isNew = useMemo(() => page.status === PageStatus.NEW, [page.status]);
+  const pageName = useMemo(() => page.name.split("/").reverse()[0], [page.name]);
 
   return (
     <>

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -1,42 +1,21 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 import { Button, Chip } from "@canonical/react-components";
 
 import { type IWebpageProps } from "./Webpage.types";
 
 import Breadcrumbs from "@/components/Breadcrumbs";
-import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
 import EditProductPanel from "@/components/EditProductPanel/EditProductPanel";
 import JiraTasks from "@/components/JiraTasks";
 import WebpageActions from "@/components/Webpage/WebpageActions";
+import WebpageDetails from "@/components/Webpage/WebpageDetails";
+import WebpageStats from "@/components/Webpage/WebpageStats";
 import WebpageAssets from "@/components/WebpageAssets";
-import config from "@/config";
 import { PageStatus } from "@/services/api/types/pages";
 import { usePanelsStore } from "@/store/app";
 
 const Webpage = ({ page, project }: IWebpageProps): ReactNode => {
   const toggleProductsPanel = usePanelsStore((state) => state.toggleProductsPanel);
-
-  const openCopyDoc = useCallback(() => {
-    window.open(page.copy_doc_link);
-  }, [page]);
-
-  const pageExtension = useMemo(() => {
-    return page.ext || ".html";
-  }, [page.ext]);
-
-  const openGitHub = useCallback(() => {
-    if (page.children?.length) {
-      window.open(`${config.ghLink(project)}${page.name}/index${pageExtension}`);
-    } else {
-      window.open(`${config.ghLink(project)}${page.name}${pageExtension}`);
-    }
-  }, [page.children?.length, page.name, pageExtension, project]);
-
-  const openFigma = useCallback(() => {
-    window.open(page.figma_link);
-  }, [page]);
-
   const isNew = useMemo(() => page.status === PageStatus.NEW, [page]);
   const pageName = useMemo(() => page.name.split("/").reverse()[0], [page]);
 
@@ -85,58 +64,15 @@ const Webpage = ({ page, project }: IWebpageProps): ReactNode => {
 
         <hr className="p-rule" />
 
-        <div className="grid-row--50-50">
-          <div className="grid-col">
-            <div className="l-webpage__details-header">
-              <h2 className="p-text--small-caps">Page Details</h2>
-              <Button appearance="base" hasIcon>
-                <i className="p-icon--edit" />
-              </Button>
-            </div>
-            <div className="l-webpage__details">
-              <div className="label u-text--muted">Published page</div>
-              <div className="value">
-                <a href={`https://${project}${page.url}`} rel="noopener noreferrer" target="_blank">
-                  View live page <i className="p-icon--external-link" />
-                </a>
-              </div>
-
-              <div className="label u-text--muted">
-                <IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} text="Owner" />
-              </div>
-              <div className="value">{page.owner.name}</div>
-
-              <div className="label u-text--muted">
-                <IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} text="Contributors" />
-              </div>
-              <div className="value">{page.reviewers.map((r) => r.name).join(", ")}</div>
-
-              <div className="label u-text--muted">Related links</div>
-              <div className="value">
-                <ul className="p-inline-list--middot">
-                  {page.copy_doc_link && (
-                    <li className="p-inline-list__item">
-                      <Button appearance="link" className="u-no-margin--bottom" onClick={openCopyDoc}>
-                        Copy doc <i className="p-icon--external-link" />
-                      </Button>
-                    </li>
-                  )}
-                  <li className="p-inline-list__item">
-                    <Button appearance="link" className="u-no-margin--bottom" onClick={openGitHub}>
-                      Github <i className="p-icon--external-link" />
-                    </Button>
-                  </li>
-                  {page.figma_link && (
-                    <li className="p-inline-list__item">
-                      <Button appearance="link" className="u-no-margin--bottom" onClick={openFigma}>
-                        Figma <i className="p-icon--external-link" />
-                      </Button>
-                    </li>
-                  )}
-                </ul>
-              </div>
-            </div>
+        <div className="grid-row--50-50 p-divider">
+          <div className="grid-col p-divider__block">
+            <WebpageDetails page={page} project={project} />
           </div>
+          {!isNew && !!page.url && (
+            <div className="grid-col p-divider__block">
+              <WebpageStats project={project} url={page.url} />
+            </div>
+          )}
         </div>
 
         <hr className="p-rule" />

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -64,18 +64,16 @@ const Webpage = ({ page, project }: IWebpageProps): ReactNode => {
 
         <hr className="p-rule" />
 
-        <div className="grid-row--50-50 p-divider">
+        <div className="grid-row--50-50-on-large p-divider">
           <div className="grid-col p-divider__block">
             <WebpageDetails page={page} project={project} />
           </div>
-          {!isNew && !!page.url && (
+          {!isNew && (
             <div className="grid-col p-divider__block">
-              <WebpageStats project={project} url={page.url} />
+              <WebpageStats project={project} url={page.url as string} />
             </div>
           )}
         </div>
-
-        <hr className="p-rule" />
 
         <WebpageAssets projectName={page.project?.name} url={page.url} />
 

--- a/static/client/pages/Webpage/_Webpage.scss
+++ b/static/client/pages/Webpage/_Webpage.scss
@@ -20,9 +20,10 @@
 
   .l-webpage__details {
     display: grid;
-    column-gap: 24px;
+    column-gap: 3rem;
     row-gap: 8px;
     grid-template-columns: max-content 1fr;
+    place-items: baseline;
   }
 
   .l-webpage__details-header {

--- a/static/client/pages/Webpage/_Webpage.scss
+++ b/static/client/pages/Webpage/_Webpage.scss
@@ -23,7 +23,47 @@
     column-gap: 3rem;
     row-gap: 8px;
     grid-template-columns: max-content 1fr;
-    place-items: baseline;
+    grid-auto-rows: 24px;
+    align-items: center;
+
+    .label,
+    .value {
+      line-height: 24px;
+    }
+
+    .value {
+      // Reset any inner elements that add extra spacing
+      .p-inline-list--middot,
+      .p-inline-list {
+        margin: 0;
+        padding: 0;
+      }
+
+      .p-button--link {
+        margin: 0;
+        padding: 0;
+        height: auto;
+        line-height: inherit;
+      }
+    }
+
+    .label span {
+      display: inline-flex !important;
+      align-items: center;
+    }
+
+    .label .u-has-icon {
+      padding: 0;
+      margin: 0;
+      margin-left: 4px;
+
+      [class*="p-icon"] {
+        width: 16px;
+        height: 16px;
+        margin: 0 !important;
+        padding: 0;
+      }
+    }
   }
 
   .l-webpage__details-header {

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
   reportBug: "/api/report-bug",
   requestFeature: "/api/request-feature",
   getTickets: "/api/tickets",
+  getWebpageStats: "/api/get-webpage-stats",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/hooks/stats.ts
+++ b/static/client/services/api/hooks/stats.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "react-query";
+
+import { PagesServices } from "@/services/api/services/pages";
+import type { IPageStats } from "@/services/api/types/pages";
+import type { IApiBasicError, IUseQueryHookRest } from "@/services/api/types/query";
+
+export function useWebpageStats(pageUrl: string, projectName: string): IUseQueryHookRest<IPageStats["data"]> {
+  const result = useQuery<IPageStats["data"], IApiBasicError>({
+    queryKey: ["webpageStats", pageUrl, projectName],
+    queryFn: () => PagesServices.getWebpageStats(pageUrl, projectName).then((response: IPageStats) => response.data),
+  });
+
+  const error = result.error;
+  const data = result.data;
+  const isLoading = result.isFetching || result.isLoading;
+
+  return { data, error, isLoading };
+}

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -6,6 +6,7 @@ import type {
   INewPage,
   INewPageResponse,
   IPagesResponse,
+  IPageStats,
   IRequestChanges,
   IRequestRemoval,
   ISetProducts,
@@ -52,5 +53,12 @@ export class PagesApiClass extends BasicApiClass {
       webpage_url: body.pageUrl,
       project_name: body.projectName,
     });
+  }
+
+  public getWebpageStats(pageUrl: string, projectName: string): Promise<IPageStats> {
+    return this.callApi(
+      `${ENDPOINTS.getWebpageStats}?url=${encodeURIComponent(pageUrl)}&project=${encodeURIComponent(projectName)}`,
+      REST_TYPES.GET,
+    );
   }
 }

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -4,6 +4,7 @@ import type {
   INewPage,
   INewPageResponse,
   IPagesResponse,
+  IPageStats,
   IRequestChanges,
   IRequestChangesResponse,
   IRequestRemoval,
@@ -41,6 +42,10 @@ export const setProducts = async (body: ISetProducts) => {
 
 export const getWebpageAssets = async (body: IGetWebpageAssets): Promise<IAssetsResponse> => {
   return api.pages.getWebpageAssets(body);
+};
+
+export const getWebpageStats = async (pageUrl: string, projectName: string): Promise<IPageStats> => {
+  return api.pages.getWebpageStats(pageUrl, projectName);
 };
 
 export * as PagesServices from "./pages";

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -104,7 +104,7 @@ export interface ISetProducts {
 export interface IPageStats {
   data: {
     last_updated: string;
-    readability_score: number;
+    readability_score: string;
     accessibility_score: number;
     link_count: number;
     prohibited_words: string[];

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -105,9 +105,9 @@ export interface IPageStats {
   data: {
     last_updated: string;
     readability_score: string;
-    accessibility_score: number;
-    link_count: number;
-    prohibited_words: string[];
-    copy_errors: number;
+    accessibility_score: number | string;
+    link_count: number | string;
+    prohibited_words: string[] | string;
+    copy_errors: number | string;
   };
 }

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -100,3 +100,14 @@ export interface ISetProducts {
   webpage_id: number;
   products: IProduct[];
 }
+
+export interface IPageStats {
+  data: {
+    last_updated: string;
+    readability_score: number;
+    accessibility_score: number;
+    link_count: number;
+    prohibited_words: string[];
+    copy_errors: number;
+  };
+}

--- a/static/client/services/dates/index.ts
+++ b/static/client/services/dates/index.ts
@@ -7,7 +7,7 @@ export function getNowStr(): string {
   return `${year}-${month}-${day}`;
 }
 
-export function beatifyDate(dateStr: string): string {
+export function beautifyDate(dateStr: string): string {
   const date = new Date(dateStr);
   const year = date.getFullYear();
   const month = date.toLocaleString("en-US", { month: "short" });

--- a/webapp/routes/product.py
+++ b/webapp/routes/product.py
@@ -92,8 +92,8 @@ def set_product(body: SetProductsModel):
                 jsonify(
                     {
                         "error": (
-                            "Integrity constraint violated. Please check "
-                            "the tags."
+                            "Integrity constraint violated. "
+                            "Please check the tags."
                         )
                     }
                 ),

--- a/webapp/routes/webpage.py
+++ b/webapp/routes/webpage.py
@@ -1,12 +1,23 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
+import yaml
 from flask_pydantic import validate
+from pathlib import Path
 
-from webapp.models import Asset, Project, Webpage, WebpageAsset, db
+from webapp.models import (
+    Asset,
+    Project,
+    Webpage,
+    WebpageAsset,
+    db,
+)
 from webapp.schemas import GetWebpageAssetsModel
+from webapp.settings import BASE_DIR
 from webapp.sso import login_required
 
-
 webpage_blueprint = Blueprint("webpage", __name__, url_prefix="/api")
+
+with open(Path(BASE_DIR) / "data/sites.yaml", "r") as f:
+    sites = yaml.safe_load(f).get("sites", [])
 
 
 @webpage_blueprint.route("/get-webpage-assets", methods=["POST"])
@@ -54,3 +65,46 @@ def get_webpage_assets(body: GetWebpageAssetsModel):
         ),
         200,
     )
+
+
+@webpage_blueprint.route("/get-webpage-stats", methods=["GET"])
+@login_required
+def get_page_stats():
+    project = request.args.get("project", type=str, default="").strip().lower()
+    if not project or project not in sites:
+        return jsonify({"error": "project is required"}), 400
+
+    webpage_url = request.args.get("url", type=str, default="").strip().lower()
+    if not webpage_url or webpage_url == "/":
+        webpage_url = ""
+
+    webpage = Webpage.query.filter_by(url=webpage_url).first()
+    if not webpage:
+        return jsonify({"error": "Webpage not found"}), 404
+
+    stats = current_app.config["CACHE"].get("PAGE_STATS_CACHE") or {}
+    stats_data = stats.get(project, {})
+    page_stats = stats_data.get(f"https://{project}{webpage_url or '/'}", {})
+
+    stats = {
+        "last_updated": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["last_updated"], "N/A"
+        ),
+        "readability_score": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["readability_score"], "N/A"
+        ),
+        "accessibility_score": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["accessibility_score"], "N/A"
+        ),
+        "link_count": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["link_count"], "N/A"
+        ),
+        "copy_errors": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["copy_errors"], "N/A"
+        ),
+        "prohibited_words": page_stats.get(
+            current_app.config["STATS_SCHEMA"]["prohibited_words"], "N/A"
+        ).split(", "),
+    }
+
+    return jsonify(stats), 200

--- a/webapp/routes/webpage.py
+++ b/webapp/routes/webpage.py
@@ -70,21 +70,31 @@ def get_webpage_assets(body: GetWebpageAssetsModel):
 @webpage_blueprint.route("/get-webpage-stats", methods=["GET"])
 @login_required
 def get_page_stats():
-    project = request.args.get("project", type=str, default="").strip().lower()
-    if not project or project not in sites:
-        return jsonify({"error": "project is required"}), 400
+    project_name = (
+        request.args.get("project", type=str, default="").strip().lower()
+    )
+    if not project_name or project_name not in sites:
+        return jsonify({"error": "Please provide a valid project"}), 400
+
+    project = Project.query.filter_by(name=project_name).first()
+    if not project:
+        return jsonify({"error": "Project not found"}), 404
 
     webpage_url = request.args.get("url", type=str, default="").strip().lower()
     if not webpage_url or webpage_url == "/":
         webpage_url = ""
 
-    webpage = Webpage.query.filter_by(url=webpage_url).first()
+    webpage = Webpage.query.filter_by(
+        url=webpage_url, project_id=project.id
+    ).first()
     if not webpage:
         return jsonify({"error": "Webpage not found"}), 404
 
     stats = current_app.config["CACHE"].get("PAGE_STATS_CACHE") or {}
-    stats_data = stats.get(project, {})
-    page_stats = stats_data.get(f"https://{project}{webpage_url or '/'}", {})
+    stats_data = stats.get(project_name, {})
+    page_stats = stats_data.get(
+        f"https://{project_name}{webpage_url or '/'}", {}
+    )
 
     stats = {
         "last_updated": page_stats.get(

--- a/webapp/scheduled_tasks.py
+++ b/webapp/scheduled_tasks.py
@@ -32,6 +32,8 @@ TASK_DELAY = int(os.getenv("TASK_DELAY", "30"))
 UPDATE_STATUS_DELAY = int(os.getenv("UPDATE_STATUS_DELAY", "5"))
 # Default delay between runs for parsing webpage assets
 PARSE_ASSETS_DELAY = int(os.getenv("PARSE_ASSETS_DELAY", "1440"))
+# Default delay between runs for parsing webpage stats
+FETCH_STATS_DELAY = int(os.getenv("FETCH_STATS_DELAY", "2880"))
 
 
 @register_task(delay=TASK_DELAY)
@@ -236,7 +238,7 @@ def parse_webpage_assets() -> None:
         app.logger.info("Finished scheduled task: parse_webpage_assets")
 
 
-@register_task(delay=2880)
+@register_task(delay=FETCH_STATS_DELAY)
 def fetch_webpage_stats() -> None:
     """Fetch webpage stats and update the database."""
     app = create_app()
@@ -269,7 +271,7 @@ def fetch_webpage_stats() -> None:
             app.config["CACHE"].set("PAGE_STATS_CACHE", index_data)
         except Exception as e:
             app.logger.error(f"Error fetching webpage stats: {e}")
-    app.logger.info("Finished scheduled task: fetch_webpage_stats")
+        app.logger.info("Finished scheduled task: fetch_webpage_stats")
 
 
 def init_scheduled_tasks(app: Flask) -> None:

--- a/webapp/scheduled_tasks.py
+++ b/webapp/scheduled_tasks.py
@@ -22,6 +22,7 @@ from webapp.settings import BASE_DIR
 from webapp.site_repository import SiteRepository
 from webapp.tasks import register_task
 from sqlalchemy.orm import joinedload
+import gspread
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +236,42 @@ def parse_webpage_assets() -> None:
         app.logger.info("Finished scheduled task: parse_webpage_assets")
 
 
+@register_task(delay=2880)
+def fetch_webpage_stats() -> None:
+    """Fetch webpage stats and update the database."""
+    app = create_app()
+    sites_data = Path(BASE_DIR) / "data/sites.yaml"
+    with open(sites_data, "r") as f:
+        sites = yaml.safe_load(f).get("sites", [])
+
+    with app.app_context():
+        app.logger.info("Running scheduled task: fetch_webpage_stats")
+        try:
+            gc = gspread.service_account_from_dict(
+                app.config["GOOGLE_CREDENTIALS"]
+            )
+            spreadsheet = gc.open_by_url(app.config["PAGE_STATS_DOC"])
+
+            worksheets = spreadsheet.worksheets()
+            data = {}
+            for worksheet in worksheets:
+                sheet_title = worksheet.title
+                if sheet_title in sites:
+                    data[sheet_title] = worksheet.get_all_records()
+
+            index_data = {}
+            for project, rows in data.items():
+                index_data[project] = {
+                    row["URL"]: row
+                    for row in rows
+                    if "URL" in row and row["URL"]
+                }
+            app.config["CACHE"].set("PAGE_STATS_CACHE", index_data)
+        except Exception as e:
+            app.logger.error(f"Error fetching webpage stats: {e}")
+    app.logger.info("Finished scheduled task: fetch_webpage_stats")
+
+
 def init_scheduled_tasks(app: Flask) -> None:
     @app.before_request
     def start_tasks():
@@ -244,3 +281,4 @@ def init_scheduled_tasks(app: Flask) -> None:
         load_site_trees()
         parse_webpage_assets()
         scheduled_tasks_alert()
+        fetch_webpage_stats()

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -69,3 +69,13 @@ BAU_BOT_WEBHOOK_URL = get_flask_env("BAU_BOT_WEBHOOK_URL")
 SSO_CLIENT_ID = get_flask_env("SSO_CLIENT_ID")
 SSO_CLIENT_SECRET = get_flask_env("SSO_CLIENT_SECRET")
 OIDC_PROVIDER = get_flask_env("OIDC_PROVIDER")
+PAGE_STATS_DOC = get_flask_env("PAGE_STATS_DOC")
+
+STATS_SCHEMA = {
+    "last_updated": "Last updated",
+    "readability_score": "Reading level",
+    "accessibility_score": "Accessibility score",
+    "link_count": "Link profile",
+    "copy_errors": "Copy style guide errors",
+    "prohibited_words": "Remove and replace these style guide errors",
+}


### PR DESCRIPTION
## Done

 - Integrated [page stats google spreadsheet](https://docs.google.com/spreadsheets/d/1X_azQbRuSOb1M3IQHkTCOa_Au2jE4PAVl6120n1caO8/edit?gid=1060324940#gid=1060324940)
 - Added stats on the dashboard

## QA

### QA steps

 - Checkout this pull request
 - Copy the `PAGE_STATS_DOC` env variable from [here](https://pastebin.canonical.com/p/4CZ8GzBqf4/) and put in your .local.env
 - Run the project using `task`
 - Access the application on localhost:8104/app
 - Search for and open a page, for example, canonical.com/solutions/ai
 - Verify the page stats are visible, and working as expected

## Fixes

 - Fixes [WD-34788](https://warthogs.atlassian.net/browse/WD-34788) [WD-34789](https://warthogs.atlassian.net/browse/WD-34789)

## Screenshots

<img width="1349" height="774" alt="image" src="https://github.com/user-attachments/assets/ca35d2a5-0e6c-41c5-853d-0e42d10039b5" />



[WD-34788]: https://warthogs.atlassian.net/browse/WD-34788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-34789]: https://warthogs.atlassian.net/browse/WD-34789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ