### PR TITLE
chore: [WD-33240] Full Site View Mobile nav

### DIFF
--- a/static/client/components/Navigation/Navigation.test.tsx
+++ b/static/client/components/Navigation/Navigation.test.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode } from "react";
 
 import { render, screen } from "@testing-library/react";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -10,28 +9,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Navigation from "./Navigation";
 
+import { useViewsStore } from "@/store/views";
+
 const mockNavigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
   return { ...actual, useNavigate: () => mockNavigate };
 });
-
-const setMatchMediaMatches = (matches: boolean) => {
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    value: (query: string) => ({
-      matches,
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => false,
-    }),
-  });
-};
 
 const renderWithQuery = (children: ReactNode) => {
   const queryClient = new QueryClient();
@@ -47,7 +32,7 @@ const renderNav = () =>
 
 beforeEach(() => {
   mockNavigate.mockClear();
-  setMatchMediaMatches(false);
+  useViewsStore.setState({ activeProject: "" });
 });
 
 describe("Navigation", () => {
@@ -59,5 +44,81 @@ describe("Navigation", () => {
   it("is collapsed by default", () => {
     renderNav();
     expect(screen.getByRole("navigation")).toHaveClass("is-collapsed");
+  });
+
+  it("clicking the desktop Full site view row navigates to /app/views/table", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByTestId("nav-link-full-site-view-desktop"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/app/views/table");
+  });
+
+  it("clicking the mobile Full site view row drills instead of navigating", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /back to main navigation/i })).toBeInTheDocument();
+  });
+
+  it("clicking the back row returns to the top-level nav", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+    await user.click(screen.getByRole("button", { name: /back to main navigation/i }));
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /back to main navigation/i })).not.toBeInTheDocument();
+  });
+
+  it("selecting a project navigates, sets activeProject, and closes the drawer", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+    await user.click(screen.getByRole("button", { name: "canonical.com" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/app/views/table");
+    expect(useViewsStore.getState().activeProject).toBe("canonical.com");
+    expect(screen.getByRole("navigation")).toHaveClass("is-collapsed");
+  });
+
+  it("the active project is marked with is-active in the sub-list", async () => {
+    const user = userEvent.setup();
+    useViewsStore.setState({ activeProject: "ubuntu.com" });
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+
+    const ubuntuRow = screen.getByRole("button", { name: "ubuntu.com" });
+    expect(ubuntuRow).toHaveClass("is-active");
+    expect(screen.getByRole("button", { name: "canonical.com" })).not.toHaveClass("is-active");
+  });
+
+  it("closing the drawer while drilled resets the drill state", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /^menu$/i }));
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+    await user.click(screen.getByRole("button", { name: /^menu$/i }));
+    await user.click(screen.getByRole("button", { name: /^menu$/i }));
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /back to main navigation/i })).not.toBeInTheDocument();
+  });
+
+  it("when drilled, the navigation gets the drilled class so CSS can hide the top-list and search", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /open project list/i }));
+
+    expect(screen.getByRole("navigation")).toHaveClass("l-navigation--drilled");
   });
 });

--- a/static/client/components/Navigation/Navigation.test.tsx
+++ b/static/client/components/Navigation/Navigation.test.tsx
@@ -1,32 +1,63 @@
 import { type ReactNode } from "react";
 
 import { render, screen } from "@testing-library/react";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import type * as ReactRouterDom from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Navigation from "./Navigation";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const setMatchMediaMatches = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+};
 
 const renderWithQuery = (children: ReactNode) => {
   const queryClient = new QueryClient();
   return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
 };
 
+const renderNav = () =>
+  renderWithQuery(
+    <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+      <Navigation />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  setMatchMediaMatches(false);
+});
+
 describe("Navigation", () => {
   it("displays navigation", () => {
-    renderWithQuery(
-      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-        <Navigation />
-      </MemoryRouter>,
-    );
+    renderNav();
     expect(screen.getByRole("navigation")).toBeInTheDocument();
   });
 
   it("is collapsed by default", () => {
-    renderWithQuery(
-      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-        <Navigation />
-      </MemoryRouter>,
-    );
+    renderNav();
     expect(screen.getByRole("navigation")).toHaveClass("is-collapsed");
   });
 });

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -8,21 +8,30 @@ import NavigationBanner from "./NavigationBanner";
 
 import NavigationCollapseToggle from "@/components/Navigation/NavigationCollapseToggle";
 import NavigationSearch from "@/components/Navigation/NavigationSearch";
-import { VIEW_OWNED, VIEW_REQUESTS, VIEW_TABLE, VIEW_TREE } from "@/config";
+import config, { VIEW_OWNED, VIEW_REQUESTS, VIEW_TABLE, VIEW_TREE } from "@/config";
 import type { IUser } from "@/services/api/types/users";
 import type { TView } from "@/services/api/types/views";
 import { useStore } from "@/store";
 import { useViewsStore } from "@/store/views";
 
+type MobileDrillTarget = "top" | "fullSiteView";
+
 const Navigation = (): ReactNode => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [isCollapsed, setIsCollapsed] = useState(true);
+  const [isCollapsed, _setIsCollapsed] = useState(true);
+  const [mobileDrilledTo, setMobileDrilledTo] = useState<MobileDrillTarget>("top");
+  const setIsCollapsed = useCallback((next: boolean) => {
+    _setIsCollapsed(next);
+    if (next) setMobileDrilledTo("top");
+  }, []);
   const [user, setUser] = useStore((state) => [state.user, state.setUser]);
-  const [view, setView, setExpandedProject] = useViewsStore((state) => [
+  const [view, setView, setExpandedProject, activeProject, setActiveProject] = useViewsStore((state) => [
     state.view,
     state.setView,
     state.setExpandedProject,
+    state.activeProject,
+    state.setActiveProject,
   ]);
   const logout = useCallback(() => {
     setUser({} as IUser);
@@ -42,6 +51,19 @@ const Navigation = (): ReactNode => {
       }
     },
     [navigate, setExpandedProject, setView],
+  );
+
+  const onMobileDrillIn = useCallback(() => {
+    setMobileDrilledTo("fullSiteView");
+  }, []);
+
+  const onSelectProject = useCallback(
+    (project: string) => {
+      setActiveProject(project);
+      changeView(VIEW_TABLE);
+      setIsCollapsed(true);
+    },
+    [changeView, setActiveProject, setIsCollapsed],
   );
 
   const isViewActive = useCallback(
@@ -67,7 +89,14 @@ const Navigation = (): ReactNode => {
           </div>
         </div>
       </header>
-      <nav aria-label="main" className={classNames("l-navigation", { "is-collapsed": isCollapsed })} role="navigation">
+      <nav
+        aria-label="main"
+        className={classNames("l-navigation", {
+          "is-collapsed": isCollapsed,
+          "l-navigation--drilled": mobileDrilledTo === "fullSiteView",
+        })}
+        role="navigation"
+      >
         <div className="l-navigation__drawer">
           <div className="p-panel is-paper">
             <div className="p-panel__header is-sticky">
@@ -77,41 +106,106 @@ const Navigation = (): ReactNode => {
               </div>
             </div>
             <div className="p-panel__content">
-              <div className="p-panel__content-search">
-                <hr className="p-rule" />
-                <p className="p-text--small-caps">Search pages</p>
-                <NavigationSearch />
-                <hr className="p-rule u-sv3" />
+              <div className="l-navigation__top-list">
+                <div className="p-panel__content-search">
+                  <hr className="p-rule" />
+                  <p className="p-text--small-caps">Search pages</p>
+                  <NavigationSearch />
+                  <hr className="p-rule u-sv3" />
+                </div>
+                <ul className="u-no-margin u-no-padding">
+                  <li
+                    className={classNames("p-side-navigation__link", { "is-active": isViewActive(VIEW_REQUESTS) })}
+                    onClick={() => changeView(VIEW_REQUESTS)}
+                  >
+                    <span className="u-has-icon">
+                      <i className="p-icon--file" />
+                      Dashboard
+                    </span>
+                  </li>
+                  <li
+                    className={classNames("p-side-navigation__link", { "is-active": isViewActive(VIEW_OWNED) })}
+                    onClick={() => changeView(VIEW_OWNED)}
+                  >
+                    <span className="u-has-icon">
+                      <i className="p-icon--file" />
+                      Your pages
+                    </span>
+                  </li>
+                  <li
+                    className={classNames("p-side-navigation__link", "l-navigation__nav-link--desktop", {
+                      "is-active": isViewActive(VIEW_TABLE),
+                    })}
+                    data-testid="nav-link-full-site-view-desktop"
+                    onClick={() => changeView(VIEW_TABLE)}
+                  >
+                    <span className="u-has-icon">
+                      <i className="p-icon--show" />
+                      Full site view
+                    </span>
+                  </li>
+                  <li
+                    aria-label="Open project list"
+                    className={classNames("p-side-navigation__link", "l-navigation__nav-link--mobile", {
+                      "is-active": isViewActive(VIEW_TABLE),
+                    })}
+                    onClick={onMobileDrillIn}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onMobileDrillIn();
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <span className="u-has-icon">
+                      <i className="p-icon--show" />
+                      Full site view
+                    </span>
+                    <i aria-hidden="true" className="p-icon--chevron-right l-navigation__drill-chevron" />
+                  </li>
+                </ul>
               </div>
-              <ul className="u-no-margin u-no-padding">
-                <li
-                  className={`p-side-navigation__link ${isViewActive(VIEW_REQUESTS) && "is-active"}`}
-                  onClick={() => changeView(VIEW_REQUESTS)}
-                >
-                  <span className="u-has-icon">
-                    <i className="p-icon--file" />
-                    Dashboard
-                  </span>
-                </li>
-                <li
-                  className={`p-side-navigation__link ${isViewActive(VIEW_OWNED) && "is-active"}`}
-                  onClick={() => changeView(VIEW_OWNED)}
-                >
-                  <span className="u-has-icon">
-                    <i className="p-icon--file" />
-                    Your pages
-                  </span>
-                </li>
-                <li
-                  className={`p-side-navigation__link ${isViewActive(VIEW_TABLE) && "is-active"}`}
-                  onClick={() => changeView(VIEW_TABLE)}
-                >
-                  <span className="u-has-icon">
-                    <i className="p-icon--show" />
-                    Full site view
-                  </span>
-                </li>
-              </ul>
+              {mobileDrilledTo === "fullSiteView" && (
+                <ul className="l-navigation__drilled-list u-no-margin u-no-padding">
+                  <li
+                    aria-label="Back to main navigation"
+                    className="p-side-navigation__link"
+                    onClick={() => setMobileDrilledTo("top")}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setMobileDrilledTo("top");
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <span className="u-has-icon">
+                      <i className="p-icon--chevron-left" />
+                      Full site view
+                    </span>
+                  </li>
+                  {config.allProjects.map((project) => (
+                    <li
+                      className={classNames("p-side-navigation__link", { "is-active": activeProject === project })}
+                      key={project}
+                      onClick={() => onSelectProject(project)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onSelectProject(project);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <span>{project}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
             <div className="p-panel__footer p-side-navigation--icons">
               {user?.name && (

--- a/static/client/components/Navigation/_Navigation.scss
+++ b/static/client/components/Navigation/_Navigation.scss
@@ -31,14 +31,14 @@
 
     .p-panel__logo {
       margin: 0;
-  
+
       @media (min-width: $breakpoint-small) {
         display: flex;
         flex: 0 0 auto;
         margin-bottom: 12px;
       }
     }
-    
+
     .l-navigation__controls,
     .l-navigation__controls > span {
       display: flex;
@@ -103,7 +103,7 @@
     overflow: visible !important;
 
     .l-logo__collapsed {
-      display :none;
+      display: none;
     }
 
     .p-panel__content {
@@ -113,5 +113,34 @@
     .p-panel__footer {
       padding-left: 0;
     }
+  }
+}
+
+.l-navigation__drill-chevron {
+  align-self: center;
+  margin-left: auto;
+}
+
+.l-navigation__nav-link--desktop {
+  @media (max-width: $breakpoint-small) {
+    display: none;
+  }
+}
+
+.l-navigation__nav-link--mobile {
+  @media (min-width: $breakpoint-small) {
+    display: none;
+  }
+}
+
+.l-navigation__drilled-list {
+  @media (min-width: $breakpoint-small) {
+    display: none;
+  }
+}
+
+@media (max-width: $breakpoint-small) {
+  .l-navigation--drilled .l-navigation__top-list {
+    display: none;
   }
 }

--- a/static/client/components/Views/FullSiteView/_FullSiteView.scss
+++ b/static/client/components/Views/FullSiteView/_FullSiteView.scss
@@ -31,9 +31,7 @@
   }
 
   @media (max-width: $breakpoint-small) {
-    max-height: fit-content;
-    width: 100%;
-    position: relative;
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Done
- Implemented the Mobile View for the secondary navigation on Full Site View

### QA steps
Make sure you're part of this [cs admins team](https://launchpad.net/~content-system-admins) on launchpad.
Checkout this pull request
Run the project using task
Access the application on localhost:8104/app
Go to Full Site View
Click the Tree View
Verify pages are displayed and looks as per [figma](https://www.figma.com/design/uVXFi46C7ZgriDoWEnsv1U/cs.canonical.com---Content-system--CMS----Sites?node-id=4639-40019&m=dev)

## Fixes

 - Fixes [WD-33240](https://warthogs.atlassian.net/browse/WD-33240)

## Screenshots
<img width="386" alt="image" src="https://github.com/user-attachments/assets/7738fbe6-187d-49a1-ae82-32efa07ad258" />



[WD-33240]: https://warthogs.atlassian.net/browse/WD-33240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ