### PR TITLE
fix(ci): pack rock action failing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-slugify==8.0.4
 black==25.1.0
 flake8==7.1.1
 Authlib==1.6.6
+flask


### PR DESCRIPTION
## Done

 - Added flask dependency in requirements.txt for pack-rock to succeed. This was introduced in recent flask-base versions.

Fixes [WD-37064](https://warthogs.atlassian.net/browse/WD-37064)

[WD-37064]: https://warthogs.atlassian.net/browse/WD-37064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ